### PR TITLE
Improve trivia attachment for `)` in parse_brackets

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2982,14 +2982,7 @@ function parse_brackets(after_parse::Function,
                 # (x \n\n for a in as)  ==>  (generator x (= a as))
                 parse_generator(ps, mark)
             else
-                if is_closing_token(ps, k)
-                    k_str = untokenize(k, unique=false)
-                    emit_diagnostic(ps, error="unexpected `$k_str` in bracketed list")
-                else
-                    ck_str = untokenize(closing_kind)
-                    emit_diagnostic(ps, error="missing comma or $ck_str in bracketed list")
-                end
-                # Recovery done after loop
+                # Error - recovery done when consuming closing_kind
                 break
             end
         end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -791,6 +791,20 @@ broken_tests = [
     end
 end
 
+@testset "Trivia attachment" begin
+    @test show_green_tree("f(a;b)") == """
+         1:6      │[toplevel]
+         1:6      │  [call]
+         1:1      │    Identifier           ✔   "f"
+         2:2      │    (                        "("
+         3:3      │    Identifier           ✔   "a"
+         4:5      │    [parameters]
+         4:4      │      ;                      ";"
+         5:5      │      Identifier         ✔   "b"
+         6:6      │    )                        ")"
+    """
+end
+
 @testset "Unicode normalization in tree conversion" begin
     # ɛµ normalizes to εμ
     @test test_parse(JuliaSyntax.parse_eq, "\u025B\u00B5()") == "(call \u03B5\u03BC)"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -250,3 +250,7 @@ function itest_parse(production, code; version::VersionNumber=v"1.6")
     nothing
 end
 
+function show_green_tree(code; version::VersionNumber=v"1.6")
+    t = JuliaSyntax.parseall(GreenNode, code, version=version)
+    sprint(show, MIME"text/plain"(), t, code)
+end


### PR DESCRIPTION
The `)` was attached to the `parameters` expression, but should be attached to node along with the opening `(` instead.

Also avoid a duplicate diagnostic messages for closing brackets