### PR TITLE
Separate UUID for the JuliaSyntax in sysimage

### DIFF
--- a/sysimage/JuliaSyntaxCore/Project.toml
+++ b/sysimage/JuliaSyntaxCore/Project.toml
@@ -7,4 +7,4 @@ version = "0.1.0"
 julia = "1.6"
 
 [deps]
-JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+JuliaSyntax = "54354a4c-6cac-4c00-8566-e7c1beb8bfd8"

--- a/sysimage/compile.jl
+++ b/sysimage/compile.jl
@@ -11,10 +11,24 @@ using Libdl
 
 cd(@__DIR__)
 
+# Create a copy of JuliaSyntax so we can change the project UUID.
+# This allows us to use an older version of JuliaSyntax for developing
+# JuliaSyntax itself.
+rm("JuliaSyntax", force=true, recursive=true)
+mkdir("JuliaSyntax")
+cp("../src", "JuliaSyntax/src")
+cp("../test", "JuliaSyntax/test")
+projstr = replace(read("../Project.toml", String),
+    "70703baa-626e-46a2-a12c-08ffd08c73b4"=>"54354a4c-6cac-4c00-8566-e7c1beb8bfd8")
+write("JuliaSyntax/Project.toml", projstr)
+
 using Pkg
+rm("Project.toml", force=true)
+rm("Manifest.toml", force=true)
 Pkg.activate(".")
-Pkg.develop("JuliaSyntax")
+Pkg.develop(path="./JuliaSyntax")
 Pkg.develop(path="./JuliaSyntaxCore")
+Pkg.add("PackageCompiler")
 
 image_path = joinpath(imgs_base_path, "juliasyntax_sysimage."*Libdl.dlext)
 


### PR DESCRIPTION
This allows us to use JuliaSyntax baked into the sysimage to develop
a separate JuliaSyntax with Revise :-D