### PR TITLE
Fix core hook when parsing only whitespace.

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -28,6 +28,12 @@ function core_parser_hook(code, filename, lineno, offset, options)
             # To copy the flisp parser driver, we ignore leading and trailing
             # trivia when parsing statements or atoms
             bump_trivia(stream)
+            if peek(stream) == K"EndMarker"
+                # If we're at the end of stream after skipping whitespace, just
+                # return `nothing` to indicate this rather than attempting to
+                # parse a statement or atom and failing.
+                return Core.svec(nothing, last_byte(stream))
+            end
         end
         JuliaSyntax.parse(stream; rule=rule)
         if rule !== :toplevel

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -1,4 +1,12 @@
 @testset "Hooks for Core integration" begin
+    @testset "parsing empty strings" begin
+        @test JuliaSyntax.core_parser_hook("", "somefile", 0, :statement) == Core.svec(nothing, 0)
+        @test JuliaSyntax.core_parser_hook("", "somefile", 0, :statement) == Core.svec(nothing, 0)
+
+        @test JuliaSyntax.core_parser_hook("  ", "somefile", 2, :statement) == Core.svec(nothing,2)
+        @test JuliaSyntax.core_parser_hook(" #==# ", "somefile", 6, :statement) == Core.svec(nothing,6)
+    end
+
     @testset "filename is used" begin
         ex = JuliaSyntax.core_parser_hook("@a", "somefile", 0, :statement)[1]
         @test Meta.isexpr(ex, :macrocall)
@@ -16,6 +24,7 @@
         @test Meta.parse("x + 1\n(y)\n", 1) == (:(x + 1), 7)
         @test Meta.parse("x + 1\n(y)\n", 7) == (:y, 11)
         @test Meta.parse(" x#==#", 1) == (:x, 7)
+        @test Meta.parse(" #==# ", 1) == (nothing, 7)
 
         # Check that Meta.parse throws the JuliaSyntax.ParseError rather than
         # Meta.ParseError when Core integration is enabled.


### PR DESCRIPTION
core_parser_hook() should return `nothing` when attempting to parse
statements or atoms, but when there's nothing but whitespace remaining.