### PR TITLE
Bugfix: Always emit a token from parse_atom

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -458,6 +458,8 @@ tests = [
         "function f() where T   end"  =>  "(function (where (call f) T) (block))"
         "function f() \n a \n b end"  =>  "(function (call f) (block a b))"
         "function f() end"       =>  "(function (call f) (block))"
+        # Errors
+        "function"            => "(function (error (error)) (block (error)) (error-t))"
     ],
     JuliaSyntax.parse_try => [
         "try \n x \n catch e \n y \n finally \n z end" =>
@@ -560,8 +562,13 @@ tests = [
         ":foo"   => "(quote foo)"
         ": foo"  => "(quote (error-t) foo)"
         # Literal colons
-        ":)"   => ":"
-        ": end"   => ":"
+        ":)"     => ":"
+        ": end"  => ":"
+        # plain equals
+        "="      => "(error =)"
+        # Identifiers
+        "xx"     => "xx"
+        "x₁"     => "x₁"
         # var syntax
         """var"x" """  =>  "x"
         """var"x"+"""  =>  "x"
@@ -586,14 +593,16 @@ tests = [
         ":.="  =>  "(quote .=)"
         # Special symbols quoted
         ":end" => "(quote end)"
-        ":(end)" => "(quote (error (end)))"
+        ":(end)" => "(quote (error-t))"
         ":<:"  => "(quote <:)"
+        # unexpect =
+        "="    => "(error =)"
         # parse_cat
         "[]"        =>  "(vect)"
         "[x,]"      =>  "(vect x)"
         "[x]"       =>  "(vect x)"
-        "[x"        =>  "(vect x (error-t))"
         "[x \n ]"   =>  "(vect x)"
+        "[x"        =>  "(vect x (error-t))"
         "[x \n\n ]" =>  "(vect x)"
         "[x for a in as]"  =>  "(comprehension (generator x (= a as)))"
         "[x \n\n for a in as]"  =>  "(comprehension (generator x (= a as)))"
@@ -625,8 +634,10 @@ tests = [
         "``"         =>  "(macrocall :(Core.var\"@cmd\") \"\")"
         "`cmd`"      =>  "(macrocall :(Core.var\"@cmd\") \"cmd\")"
         "```cmd```"  =>  "(macrocall :(Core.var\"@cmd\") \"cmd\")"
-        # Errors
-        ": foo" => "(quote (error-t) foo)"
+        # literals
+        "42"   => "42"
+        # closing tokens
+        ")"    => "(error)"
     ],
     JuliaSyntax.parse_atom => [
         # Actually parse_array

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -243,7 +243,7 @@ function itest_parse(production, code; version::VersionNumber=v"1.6")
         show(stdout, MIME"text/plain"(), f_ex)
 
         printstyled(stdout, "\n\n# Diff of AST dump:\n", color=:red)
-        show_expr_text_diff(showfunc, ex, f_ex, context=10)
+        show_expr_text_diff(show, ex, f_ex, context=10)
         # return (ex, f_ex)
         # return (code, stream, t, s, ex)
     end


### PR DESCRIPTION
If a closing token is found in parse_atom, we still need to emit a
nontrivia token to make the resulting parse tree consistent. We choose
an invisible token for this.

Also add various minor fixes to error recovory and a few additional
tests in parse_atom and elsewhere.

Fixes #43 