### PR TITLE
Make enable_in_core! safe for use in precompilation

### DIFF
--- a/sysimage/JuliaSyntaxCore/src/JuliaSyntaxCore.jl
+++ b/sysimage/JuliaSyntaxCore/src/JuliaSyntaxCore.jl
@@ -5,22 +5,8 @@ module JuliaSyntaxCore
 
 using JuliaSyntax
 
-import Base: JLOptions
-
 function __init__()
-    # HACK! Fool the runtime into allowing us to set Core._parse, even during
-    # incremental compilation. (Ideally we'd just arrange for Core._parse to be
-    # set to the JuliaSyntax parser. But how do we signal that to the dumping
-    # code outside of the initial creation of Core?)
-    i = findfirst(==(:incremental), fieldnames(JLOptions))
-    ptr = convert(Ptr{fieldtype(JLOptions, i)},
-                  cglobal(:jl_options, JLOptions) + fieldoffset(JLOptions, i))
-    incremental = unsafe_load(ptr)
-    incremental == 0 || unsafe_store!(ptr, 0)
-
     JuliaSyntax.enable_in_core!()
-
-    incremental == 0 || unsafe_store!(ptr, incremental)
 end
 
 end


### PR DESCRIPTION
Move the hacky code for overriding Core._parse from the sysimage
init module into JuliaSyntax.jl proper, to allow it to be reused as
necessary.