### PR TITLE
generate `:incomplete` expression

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -92,8 +92,11 @@ function _core_parser_hook(code, filename, lineno, offset, options)
             bump_trivia(stream)
         end
 
-        if any_error(stream)
-            e = Expr(:error, ParseError(SourceFile(code, filename=filename), stream.diagnostics))
+        incomplete = is_incomplete(stream)
+        error = any_error(stream)
+        if incomplete || error
+            err = ParseError(SourceFile(code, filename=filename), stream.diagnostics)
+            e = Expr(incomplete ? :incomplete : :error, err)
             ex = options === :all ? Expr(:toplevel, e) : e
         else
             ex = build_tree(Expr, stream, filename=filename, wrap_toplevel_as_kind=K"None")

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -151,7 +151,7 @@ function bump_closing_token(ps, closing_kind)
     end
     # mark as trivia => ignore in AST.
     emit(ps, mark, K"error", TRIVIA_FLAG,
-         error="Expected `$(untokenize(closing_kind))`")
+         incomplete="Expected `$(untokenize(closing_kind))`")
     if peek(ps) == closing_kind
         bump(ps, TRIVIA_FLAG)
     end
@@ -164,7 +164,7 @@ function recover(is_closer::Function, ps, flags=EMPTY_FLAGS; mark = position(ps)
         k = peek(ps)
         if k == K"EndMarker"
             bump_invisible(ps, K"error", TRIVIA_FLAG,
-                           error="premature end of input")
+                           incomplete="premature end of input")
             break
         elseif is_closer(ps, k)
             break
@@ -3387,10 +3387,11 @@ function parse_atom(ps::ParseState, check_identifiers=true)
         # Leave closing token in place for other productions to
         # recover with
         # )  ==>  error
-        msg = leading_kind == K"EndMarker" ?
-              "premature end of input" :
-              "unexpected closing token"
-        bump_invisible(ps, K"error", error=msg)
+        if leading_kind == K"EndMarker"
+            bump_invisible(ps, K"error", incomplete="premature end of input")
+        else
+            bump_invisible(ps, K"error", error="unexpected closing token")
+        end
     else
         bump(ps, error="invalid syntax atom")
     end

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -155,7 +155,7 @@ function parseall(::Type{T}, input...; rule=:toplevel, version=VERSION,
        (!ignore_trivia && (peek(stream, skip_newlines=false, skip_whitespace=false) != K"EndMarker"))
         emit_diagnostic(stream, error="unexpected text after parsing $rule")
     end
-    if any_error(stream.diagnostics)
+    if any_error(stream)
         source = SourceFile(sourcetext(stream, steal_textbuf=true), filename=filename)
         throw(ParseError(source, stream.diagnostics))
     end
@@ -174,4 +174,3 @@ function parseall(::Type{T}, input...; rule=:toplevel, version=VERSION,
     end
     tree
 end
-

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -1,4 +1,3 @@
-
 @testset "Expr conversion" begin
     @testset "Quote nodes" begin
         @test parseall(Expr, ":(a)", rule=:atom) == QuoteNode(:a)

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -31,7 +31,17 @@
 
         # Check that Meta.parse throws the JuliaSyntax.ParseError rather than
         # Meta.ParseError when Core integration is enabled.
-        @test_throws JuliaSyntax.ParseError Meta.parse("[x")
+        @test_throws JuliaSyntax.ParseError Meta.parse("a b")
+
+        # generate :incomplete expressions
+        for s = String[
+                "1 + ",
+                "code_typed((Float64,)) do x",
+                "[a for a = 1:10",
+                "(a for a = 1:10"
+            ]
+            @test Meta.isexpr(Meta.parse(s), :incomplete)
+        end
 
         JuliaSyntax.enable_in_core!(false)
     end


### PR DESCRIPTION
This commit setups a specific diagnostic level `:incomplete` to distinguish
incomplete cases from the other general error cases.
Does this approach sound reasonable?

fix #42