### PR TITLE
fix parsing hex floats containing 'f'

### DIFF
--- a/src/value_parsing.jl
+++ b/src/value_parsing.jl
@@ -20,7 +20,7 @@ function julia_string_to_number(str::AbstractString, kind)
         end
         return x
     elseif kind == K"Float"
-        if !startswith(str,"0x") && 'f' in str
+        if !startswith(str,"0x") && 'f' in str && !('p' in str)
             # This is kind of awful. Should we have a separate Float32 literal
             # type produced by the lexer?  The `f` suffix is nonstandard after all.
             return Base.parse(Float32, replace(str, 'f'=>'e'))

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -641,6 +641,7 @@ tests = [
         "```cmd```"  =>  "(macrocall :(Core.var\"@cmd\") \"cmd\")"
         # literals
         "42"   => "42"
+        "0x1.428a2f98d728bp+341" => "5.643803094122362e102"
         # closing tokens
         ")"    => "(error)"
     ],


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/JuliaSyntax.jl/issues/64