### PR TITLE
change highlight color from an RGB value to `Base.error_color()`

### DIFF
--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -79,7 +79,7 @@ function show_diagnostic(io::IO, diagnostic::Diagnostic, source::SourceFile)
     a,b = source_line_range(source, p, context_lines_before=2, context_lines_after=1)
     c,d = source_line_range(source, q, context_lines_before=1, context_lines_after=2)
 
-    hicol = (100,40,40)
+    hicol = Base.error_color()
 
     # TODO: show line numbers on left
 


### PR DESCRIPTION
RGB colors have very spotty support in terminals so probably better to use something more standard. `Base.error_color()` is by default `:light_red` but can also be customized with an env var.

Fixes https://github.com/JuliaLang/JuliaSyntax.jl/issues/61