### PR TITLE
Fix: .- and .+ before numeric literals

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1101,7 +1101,7 @@ function parse_unary(ps::ParseState)
         parse_factor(ps)
         return
     end
-    if k in KSet"- +"
+    if k in KSet"- +" && !is_decorated(t)
         t2 = peek_token(ps, 2)
         if !preceding_whitespace(t2) && kind(t2) in KSet"Integer Float"
             k3 = peek(ps, 3)
@@ -1116,13 +1116,18 @@ function parse_unary(ps::ParseState)
             else
                 # We have a signed numeric literal. Glue the operator to the
                 # next token to create a signed literal:
-                # +2    ==>  +2
+                # -2    ==>  -2
+                # +2.0  ==>  2.0
                 # -2*x  ==>  (call-i -2 * x)
                 bump_glue(ps, kind(t2), EMPTY_FLAGS, 2)
             end
             return
         end
     end
+    # Things which are not quite negative literals result in a unary call instead
+    # -0x1 ==>  (call - 0x01)
+    # - 2  ==>  (call - 2)
+    # .-2  ==>  (call .- 2)
     parse_unary_call(ps)
 end
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -129,11 +129,7 @@ tests = [
     ],
     JuliaSyntax.parse_term => [
         "a * b * c"  => "(call-i a * b c)"
-        # parse_unary
-        "-2*x"   =>  "(call-i -2 * x)"
-        ":T"     =>  "(quote T)"
-        "in::T"  =>  "(:: in T)"
-        "isa::T" =>  "(:: isa T)"
+        "-2*x"       => "(call-i -2 * x)"
     ],
     JuliaSyntax.parse_juxtapose => [
         "2x"         => "(call-i 2 * x)"
@@ -153,9 +149,16 @@ tests = [
         "0xenomorph" => "0x0e"
     ],
     JuliaSyntax.parse_unary => [
-        "+2"       => "2"
+        ":T"       => "(quote T)"
+        "in::T"    => "(:: in T)"
+        "isa::T"   => "(:: isa T)"
         "-2^x"     => "(call - (call-i 2 ^ x))"
         "-2[1, 3]" => "(call - (ref 2 1 3))"
+        "-2"       => "-2"
+        "+2.0"     => "2.0"
+        "-0x1"     => "(call - 0x01)"
+        "- 2"      => "(call - 2)"
+        ".-2"      => "(call .- 2)"
     ],
     JuliaSyntax.parse_unary_call => [
         # Standalone dotted operators are parsed as (|.| op)


### PR DESCRIPTION
`-2` is numeric literal `-2`, but ensure `.-2` should be `(call .- 2)`

Fixes #63 