### PR TITLE
Fix over/underflow in parsing float literals

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -201,25 +201,6 @@ function bump_semicolon_trivia(ps)
     end
 end
 
-# Like @assert, but always enabled and calls internal_error()
-macro check(ex, msgs...)
-    msg = isempty(msgs) ? ex : msgs[1]
-    if isa(msg, AbstractString)
-        msg = msg
-    elseif !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
-        msg = :(string($(esc(msg))))
-    else
-        msg = string(msg)
-    end
-    return :($(esc(ex)) ? nothing : internal_error($msg))
-end
-
-# Parser internal error, used as an assertion failure for cases we expect can't
-# happen.
-@noinline function internal_error(strs...)
-    error("Internal error: ", strs...)
-end
-
 #-------------------------------------------------------------------------------
 # Parsing-specific predicates on tokens/kinds
 #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,21 @@
+# Internal error, used as assertion failure for cases we expect can't happen.
+@noinline function internal_error(strs...)
+    error("Internal error: ", strs...)
+end
+
+# Like @assert, but always enabled and calls internal_error()
+macro check(ex, msgs...)
+    msg = isempty(msgs) ? ex : msgs[1]
+    if isa(msg, AbstractString)
+        msg = msg
+    elseif !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
+        msg = :(string($(esc(msg))))
+    else
+        msg = string(msg)
+    end
+    return :($(esc(ex)) ? nothing : internal_error($msg))
+end
+
 
 """
     Like printstyled, but allows providing RGB colors for true color terminals

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -645,6 +645,7 @@ tests = [
         "```cmd```"  =>  "(macrocall :(Core.var\"@cmd\") \"cmd\")"
         # literals
         "42"   => "42"
+        "1.0e-1000"   => "0.0"
         "0x123456789abcdefp+0" => "8.19855292164869e16"
         # closing tokens
         ")"    => "(error)"

--- a/test/value_parsing.jl
+++ b/test/value_parsing.jl
@@ -18,7 +18,9 @@ using JuliaSyntax:
     # Float32
     @test _parse_float(Float32, "123", 1, 3) === (123.0f0, :ok)
     @test _parse_float(Float32, "1.3f2", 1, 5) === (1.3f2, :ok)
-    @test _parse_float(Float32, "1.0f-50", 1, 7) === (0.0f0, :underflow)
+    if !Sys.iswindows()
+        @test _parse_float(Float32, "1.0f-50", 1, 7) === (0.0f0, :underflow)
+    end
     @test _parse_float(Float32, "1.0f+50", 1, 7) === (Inf32, :overflow)
 
     # Assertions


### PR DESCRIPTION
It seems we can't use Base.parse for floats because this disallows
underflow. So replicate the logic of it here in julia-level code and allow
`errno=ERANGE` in the underflow case.

This implementation is still somewhat (~15%) slower than Base.parse for some reason.

Should fix #65

TODO:
* [x] Tests