### PR TITLE
Use `K"?"` for head of ternary conditional

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -24,9 +24,13 @@ function _to_expr(node::SyntaxNode, iteration_spec=false, need_linenodes=true)
             return val
         end
     end
-    headstr = untokenize(head(node), include_flag_suff=false)
-    headsym = !isnothing(headstr) ? Symbol(headstr) :
-        error("Can't untokenize head of kind $(kind(node))")
+    if kind(node) == K"?"
+        headsym = :if
+    else
+        headstr = untokenize(head(node), include_flag_suff=false)
+        headsym = !isnothing(headstr) ? Symbol(headstr) :
+            error("Can't untokenize head of kind $(kind(node))")
+    end
     node_args = children(node)
     insert_linenums = (headsym == :block || headsym == :toplevel) && need_linenodes
     args = Vector{Any}(undef, length(node_args)*(insert_linenums ? 2 : 1))

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -602,7 +602,7 @@ function parse_pair(ps::ParseState)
 end
 
 # Parse short form conditional expression
-# a ? b : c ==> (if a b c)
+# a ? b : c ==> (? a b c)
 #
 # flisp: parse-cond
 function parse_cond(ps::ParseState)
@@ -613,38 +613,38 @@ function parse_cond(ps::ParseState)
         return
     end
     if !preceding_whitespace(t)
-        # a? b : c  => (if a (error-t) b c)
+        # a? b : c  => (? a (error-t) b c)
         bump_invisible(ps, K"error", TRIVIA_FLAG,
                        error="space required before `?` operator")
     end
     bump(ps, TRIVIA_FLAG) # ?
     t = peek_token(ps)
     if !preceding_whitespace(t)
-        # a ?b : c
+        # a ?b : c  ==>  (? a (error-t) b c)
         bump_invisible(ps, K"error", TRIVIA_FLAG,
                        error="space required after `?` operator")
     end
     parse_eq_star(ParseState(ps, range_colon_enabled=false))
     t = peek_token(ps)
     if !preceding_whitespace(t)
-        # a ? b: c  ==>  (if a [ ] [?] [ ] b (error-t) [:] [ ] c)
+        # a ? b: c  ==>  (? a b (error-t) c)
         bump_invisible(ps, K"error", TRIVIA_FLAG,
                        error="space required before `:` in `?` expression")
     end
     if kind(t) == K":"
         bump(ps, TRIVIA_FLAG)
     else
-        # a ? b c  ==>  (if a b (error) c)
+        # a ? b c  ==>  (? a b (error-t) c)
         bump_invisible(ps, K"error", TRIVIA_FLAG, error="`:` expected in `?` expression")
     end
     t = peek_token(ps)
     if !preceding_whitespace(t)
-        # a ? b :c  ==>  (if a [ ] [?] [ ] b [ ] [:] (error-t) c)
+        # a ? b :c  ==>  (? a b (error-t) c)
         bump_invisible(ps, K"error", TRIVIA_FLAG,
                        error="space required after `:` in `?` expression")
     end
     parse_eq_star(ps)
-    emit(ps, mark, K"if")
+    emit(ps, mark, K"?")
 end
 
 # Parse arrows.  Like parse_RtoL, but specialized for --> syntactic operator

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -52,16 +52,16 @@ tests = [
         "a => b"  =>  "(call-i a => b)"
     ],
     JuliaSyntax.parse_cond => [
-        "a ? b : c"   => "(if a b c)"
-        "a ?\nb : c"  => "(if a b c)"
-        "a ? b :\nc"  => "(if a b c)"
-        "a ? b : c:d" =>   "(if a b (call-i c : d))"
+        "a ? b : c"   => "(? a b c)"
+        "a ?\nb : c"  => "(? a b c)"
+        "a ? b :\nc"  => "(? a b c)"
+        "a ? b : c:d" =>   "(? a b (call-i c : d))"
         # Following are errors but should recover
-        "a? b : c"    => "(if a (error-t) b c)"
-        "a ?b : c"    => "(if a (error-t) b c)"
-        "a ? b: c"    => "(if a b (error-t) c)"
-        "a ? b :c"    => "(if a b (error-t) c)"
-        "a ? b c"     => "(if a b (error-t) c)"
+        "a? b : c"    => "(? a (error-t) b c)"
+        "a ?b : c"    => "(? a (error-t) b c)"
+        "a ? b: c"    => "(? a b (error-t) c)"
+        "a ? b :c"    => "(? a b (error-t) c)"
+        "a ? b c"     => "(? a b (error-t) c)"
     ],
     JuliaSyntax.parse_arrow => [
         "x → y"     =>  "(call-i x → y)"


### PR DESCRIPTION
This allows `a ? b : c` syntax to be clearly distinguished from normal
`if a b else c end` without reparsing syntax trivia.

For compatibility we convert to `:if` for normal `Expr`