### PR TITLE
Handle error nodes in Expr construction

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -27,6 +27,10 @@ function _to_expr(node::SyntaxNode, iteration_spec=false, need_linenodes=true)
     headstr = untokenize(head(node), include_flag_suff=false)
     headsym = !isnothing(headstr) ? Symbol(headstr) :
         error("Can't untokenize head of kind $(kind(node))")
+    if headsym == :error
+        return Expr(:error)
+    end
+
     node_args = children(node)
     insert_linenums = (headsym == :block || headsym == :toplevel) && need_linenodes
     args = Vector{Any}(undef, length(node_args)*(insert_linenums ? 2 : 1))


### PR DESCRIPTION
This makes `parse(Expr, ...)` succeed even when error nodes were emitted previously. 

I'm not sure we even want this, but I feel like there's some value to never getting an exception when parsing arbitrary invalid code. 