### PR TITLE
Always use string nodes wrapping string chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,17 @@ The syntax `a ? b : c` is the same as `if a b else c` in `Expr` so macros can't
 distinguish these cases. Instead, we use a distinct expression head `K"?"` and
 lower to `Expr(:if)` during `Expr` conversion.
 
+### String nodes always wrapped in `K"string"` or `K"cmdstring"`
+
+All strings are surrounded by a node of kind `K"string"`, even non-interpolated
+literals, so `"x"` parses as `(string "x")`. This makes string handling simpler
+and more systematic because interpolations and triple strings with embedded
+trivia don't need to be treated differently. It also gives a container in which
+to attach the delimiting quotes.
+
+The same goes for command strings which are always wrapped in `K"cmdstring"`
+regardless of whether they have multiple pieces (due to triple-quoted
+dedenting) or otherwise.
 
 ## More about syntax kinds
 

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -871,6 +871,7 @@ const _kind_names =
         "curly"
         "inert"          # QuoteNode; not quasiquote
         "string"         # A string interior node (possibly containing interpolations)
+        "cmdstring"      # A cmd string node (containing delimiters plus string)
         "macrocall"
         "kw"             # the = in f(a=1)
         "parameters"     # the list after ; in f(; a=1)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -144,4 +144,17 @@
                       LineNumberNode(2),
                       :body))
     end
+
+    @testset "String conversions" begin
+        # String unwrapping / wrapping
+        @test parseall(Expr, "\"str\"", rule=:statement) == "str"
+        @test parseall(Expr, "\"\$(\"str\")\"", rule=:statement) ==
+            Expr(:string, Expr(:string, "str"))
+        # Concatenation of string chunks in triple quoted cases
+        @test parseall(Expr, "```\n  a\n  b```", rule=:statement) ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@cmd")), LineNumberNode(1),
+                 "a\nb")
+        @test parseall(Expr, "\"\"\"\n  a\n  \$x\n  b\n  c\"\"\"", rule=:statement) ==
+            Expr(:string, "a\n", :x, "\nb\nc")
+    end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -33,7 +33,7 @@ tests = [
         "a;b;c"   => "(toplevel a b c)"
         "a;;;b;;" => "(toplevel a b)"
         """ "x" a ; "y" b """ =>
-            """(toplevel (macrocall :(Core.var"@doc") "x" a) (macrocall :(Core.var"@doc") "y" b))"""
+            """(toplevel (macrocall :(Core.var"@doc") (string "x") a) (macrocall :(Core.var"@doc") (string "y") b))"""
         "x y"  =>  "x (error-t y)"
     ],
     JuliaSyntax.parse_eq => [
@@ -140,8 +140,8 @@ tests = [
         "(x-1)y"     => "(call-i (call-i x - 1) * y)"
         "x'y"        => "(call-i (' x) * y)"
         # errors
-        "\"a\"\"b\"" => "(call-i \"a\" * (error-t) \"b\")"
-        "\"a\"x"     => "(call-i \"a\" * (error-t) x)"
+        "\"a\"\"b\"" => "(call-i (string \"a\") * (error-t) (string \"b\"))"
+        "\"a\"x"     => "(call-i (string \"a\") * (error-t) x)"
         # Not juxtaposition - parse_juxtapose will consume only the first token.
         "x.3"       =>  "x"
         "sqrt(2)2"  =>  "(call sqrt 2)"
@@ -254,9 +254,9 @@ tests = [
         "@foo (x,y)"   =>  "(macrocall @foo (tuple x y))"
         "A.@foo a b"   =>  "(macrocall (. A (quote @foo)) a b)"
         "@A.foo a b"   =>  "(macrocall (. A (quote @foo)) a b)"
-        "[@foo \"x\"]"   =>  "(vect (macrocall @foo \"x\"))"
-        "[f (x)]"     =>  "(hcat f x)"
-        "[f \"x\"]"   =>  "(hcat f \"x\")"
+        "[@foo x]"   =>  "(vect (macrocall @foo x))"
+        "[f (x)]"    =>  "(hcat f x)"
+        "[f x]"      =>  "(hcat f x)"
         # Macro names
         "@! x"  => "(macrocall @! x)"
         "@.. x" => "(macrocall @.. x)"
@@ -309,20 +309,20 @@ tests = [
         "S{a,b}"  => "(curly S a b)"
         "S {a}"   =>  "(curly S (error-t) a)"
         # String macros
-        "x\"str\""   => """(macrocall @x_str "str")"""
-        "x`str`"     => """(macrocall @x_cmd "str")"""
-        "x\"\""      => """(macrocall @x_str "")"""
-        "x``"        => """(macrocall @x_cmd "")"""
+        "x\"str\""   => """(macrocall @x_str (string-r "str"))"""
+        "x`str`"     => """(macrocall @x_cmd (cmdstring-r "str"))"""
+        "x\"\""      => """(macrocall @x_str (string-r ""))"""
+        "x``"        => """(macrocall @x_cmd (cmdstring-r ""))"""
         # Triple quoted procesing for custom strings
-        "r\"\"\"\nx\"\"\""        => raw"""(macrocall @r_str "x")"""
+        "r\"\"\"\nx\"\"\""        => raw"""(macrocall @r_str (string-sr "x"))"""
         "r\"\"\"\n x\n y\"\"\""   => raw"""(macrocall @r_str (string-sr "x\n" "y"))"""
         "r\"\"\"\n x\\\n y\"\"\"" => raw"""(macrocall @r_str (string-sr "x\\\n" "y"))"""
         # Macro sufficies can include keywords and numbers
-        "x\"s\"y"    => """(macrocall @x_str "s" "y")"""
-        "x\"s\"end"  => """(macrocall @x_str "s" "end")"""
-        "x\"s\"in"   => """(macrocall @x_str "s" "in")"""
-        "x\"s\"2"    => """(macrocall @x_str "s" 2)"""
-        "x\"s\"10.0" => """(macrocall @x_str "s" 10.0)"""
+        "x\"s\"y"    => """(macrocall @x_str (string-r "s") "y")"""
+        "x\"s\"end"  => """(macrocall @x_str (string-r "s") "end")"""
+        "x\"s\"in"   => """(macrocall @x_str (string-r "s") "in")"""
+        "x\"s\"2"    => """(macrocall @x_str (string-r "s") 2)"""
+        "x\"s\"10.0" => """(macrocall @x_str (string-r "s") 10.0)"""
     ],
     JuliaSyntax.parse_resword => [
         # In normal_context
@@ -381,7 +381,7 @@ tests = [
         "module do \n end"  =>  "(module true (error (do)) (block))"
         "module \$A end"    =>  "(module true (\$ A) (block))"
         "module A \n a \n b \n end"  =>  "(module true A (block a b))"
-        """module A \n "x"\na\n end""" => """(module true A (block (macrocall :(Core.var"@doc") "x" a)))"""
+        """module A \n "x"\na\n end""" => """(module true A (block (macrocall :(Core.var"@doc") (string "x") a)))"""
         # export
         "export a"  =>  "(export a)"
         "export @a"  =>  "(export @a)"
@@ -647,9 +647,9 @@ tests = [
         # __dot__ macro
         "@. x y" => "(macrocall @__dot__ x y)"
         # cmd strings
-        "``"         =>  "(macrocall :(Core.var\"@cmd\") \"\")"
-        "`cmd`"      =>  "(macrocall :(Core.var\"@cmd\") \"cmd\")"
-        "```cmd```"  =>  "(macrocall :(Core.var\"@cmd\") \"cmd\")"
+        "``"         =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-r \"\"))"
+        "`cmd`"      =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-r \"cmd\"))"
+        "```cmd```"  =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-sr \"cmd\"))"
         # literals
         "42"   => "42"
         "1.0e-1000"   => "0.0"
@@ -706,15 +706,15 @@ tests = [
         # parse_string
         "\"a \$(x + y) b\""  =>  "(string \"a \" (call-i x + y) \" b\")"
         "\"hi\$(\"ho\")\""   =>  "(string \"hi\" (string \"ho\"))"
-        "\"hi\$(\"\"\"ho\"\"\")\""  =>  "(string \"hi\" (string-s \"ho\"))"
         "\"a \$foo b\""  =>  "(string \"a \" foo \" b\")"
         "\"\$var\""      =>  "(string var)"
         "\"\$outer\""    =>  "(string outer)"
         "\"\$in\""       =>  "(string in)"
-        raw"\"\xqqq\""   =>  "✘"
+        raw"\"\xqqq\""   =>  "(string ✘)"
         # Triple-quoted dedenting:
-        "\"\"\"\nx\"\"\""   =>  "\"x\""
+        "\"\"\"\nx\"\"\""   =>  raw"""(string-s "x")"""
         "\"\"\"\n\nx\"\"\"" =>  raw"""(string-s "\n" "x")"""
+        "```\n x\n y```"    =>  raw"""(macrocall :(Core.var"@cmd") (cmdstring-sr "x\n" "y"))"""
         # Various newlines (\n \r \r\n) and whitespace (' ' \t)
         "\"\"\"\n x\n y\"\"\""  =>  raw"""(string-s "x\n" "y")"""
         "\"\"\"\r x\r y\"\"\""  =>  raw"""(string-s "x\n" "y")"""
@@ -738,14 +738,14 @@ tests = [
         "\"\"\"\n  \$a \n  \$b\"\"\""  =>  raw"""(string-s a " \n" b)"""
         "\"\"\"\n  \$a\n  \$b\n\"\"\""  =>  raw"""(string-s "  " a "\n" "  " b "\n")"""
         # Empty chunks after dedent are removed
-        "\"\"\"\n \n \"\"\""  =>  "\"\\n\""
+        "\"\"\"\n \n \"\"\""  =>  "(string-s \"\\n\")"
         # Newline at end of string
         "\"\"\"\n x\n y\n\"\"\""  =>  raw"""(string-s " x\n" " y\n")"""
         # Empty strings, or empty after triple quoted processing
-        "\"\""              =>  "\"\""
-        "\"\"\"\n  \"\"\""  =>  "\"\""
+        "\"\""              =>  "(string \"\")"
+        "\"\"\"\n  \"\"\""  =>  "(string-s \"\")"
         # Missing delimiter
-        "\"str"  =>  "\"str\" (error-t)"
+        "\"str"  =>  "(string \"str\" (error-t))"
         # String interpolations
         "\"\$x\$y\$z\""  =>  "(string x y z)"
         "\"\$(x)\""  =>  "(string x)"
@@ -756,17 +756,20 @@ tests = [
         "\"a\\\r\nb\""   =>  raw"""(string "a" "b")"""
         "\"a\\\n \tb\""  =>  raw"""(string "a" "b")"""
         # Strings with only a single valid string chunk
-        "\"str\""  =>  "\"str\""
+        "\"str\""     => "(string \"str\")"
+        "\"a\\\n\""   => "(string \"a\")"
+        "\"a\\\r\""   => "(string \"a\")"
+        "\"a\\\r\n\"" => "(string \"a\")"
     ],
     JuliaSyntax.parse_docstring => [
-        """ "notdoc" ]        """ => "\"notdoc\""
-        """ "notdoc" \n]      """ => "\"notdoc\""
-        """ "notdoc" \n\n foo """ => "\"notdoc\""
-        """ "doc" \n foo      """ => """(macrocall :(Core.var"@doc") "doc" foo)"""
-        """ "doc" foo         """ => """(macrocall :(Core.var"@doc") "doc" foo)"""
+        """ "notdoc" ]        """ => "(string \"notdoc\")"
+        """ "notdoc" \n]      """ => "(string \"notdoc\")"
+        """ "notdoc" \n\n foo """ => "(string \"notdoc\")"
+        """ "doc" \n foo      """ => """(macrocall :(Core.var"@doc") (string "doc") foo)"""
+        """ "doc" foo         """ => """(macrocall :(Core.var"@doc") (string "doc") foo)"""
         """ "doc \$x" foo     """ => """(macrocall :(Core.var"@doc") (string "doc " x) foo)"""
         # Allow docstrings with embedded trailing whitespace trivia
-        "\"\"\"\n doc\n \"\"\" foo"  => """(macrocall :(Core.var"@doc") "doc\\n" foo)"""
+        "\"\"\"\n doc\n \"\"\" foo"  => """(macrocall :(Core.var"@doc") (string-s "doc\\n") foo)"""
     ],
 ]
 
@@ -842,8 +845,8 @@ end
     # ɛµ normalizes to εμ
     @test test_parse(JuliaSyntax.parse_eq, "\u025B\u00B5()") == "(call \u03B5\u03BC)"
     @test test_parse(JuliaSyntax.parse_eq, "@\u025B\u00B5") == "(macrocall @\u03B5\u03BC)"
-    @test test_parse(JuliaSyntax.parse_eq, "\u025B\u00B5\"\"") == "(macrocall @\u03B5\u03BC_str \"\")"
-    @test test_parse(JuliaSyntax.parse_eq, "\u025B\u00B5``") == "(macrocall @\u03B5\u03BC_cmd \"\")"
+    @test test_parse(JuliaSyntax.parse_eq, "\u025B\u00B5\"\"") == "(macrocall @\u03B5\u03BC_str (string-r \"\"))"
+    @test test_parse(JuliaSyntax.parse_eq, "\u025B\u00B5``") == "(macrocall @\u03B5\u03BC_cmd (cmdstring-r \"\"))"
     # · and · normalize to ⋅
     @test test_parse(JuliaSyntax.parse_eq, "a \u00B7 b") == "(call-i a \u22C5 b)"
     @test test_parse(JuliaSyntax.parse_eq, "a \u0387 b") == "(call-i a \u22C5 b)"


### PR DESCRIPTION
Ensures that strings are always encapsulated within a
`string` internal node of the parse tree, giving a place to include the
delimiters and unifying interpolated strings / strings with internal
whitespace with plain string literals.

~~Also, wrap `K"$"` nodes around interpolations in strings~~ - update: removed this part

That is, parse
  `"a $x b"`
as
  `(string "a " ($ x) " b")`

This makes the presence of interpolation syntax explicit, just as it is
for interpolation into expression literals.

There's two advantages of this

* We don't need a hack to distinguish "$("str")" from "str". This seems
  necessary now that all strings are wrapped in K"string" nodes, as the
  older hack doesn't work (hmm on second thoughts ... I think?)
* The `$` node gives a place to attach delimiter trivia, which makes it
  easy to distinguish `"$(x)"` from `"$x"`. (Though with a `K"parens"`
  node coming soon maybe that's not necessary?)

I'm not quite 100% sure we want this second part with the interpolation nodes ... might need to think about it a little more.

Part of #88