### PR TITLE
Remove Mmap as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 julia = "1.6"
 
 [deps]
-Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [extras]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -1,7 +1,5 @@
 module JuliaSyntax
 
-using Mmap
-
 # Helper utilities
 include("utils.jl")
 

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -250,10 +250,6 @@ function ParseStream(io::Base.GenericIOBuffer; version=VERSION)
     textbuf = unsafe_wrap(Vector{UInt8}, pointer(io.data), length(io.data))
     ParseStream(textbuf, io, position(io)+1, version)
 end
-function ParseStream(io::IOStream; version=VERSION)
-    textbuf = Mmap.mmap(io)
-    ParseStream(textbuf, io, position(io)+1, version)
-end
 function ParseStream(io::IO; version=VERSION)
     textbuf = read(io)
     ParseStream(textbuf, textbuf, 1, version)


### PR DESCRIPTION
We can use Mmap for mapping IOStream but
* It's not clear that this is necessary
* Removing it avoids stdlib dependencies, making Base integration easier.