### PR TITLE
Generate `Expr(:incomplete)`

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -46,6 +46,11 @@ struct ParseError <: Exception
     diagnostics::Vector{Diagnostic}
 end
 
+function ParseError(stream::ParseStream; filename=nothing)
+    source = SourceFile(sourcetext(stream), filename=filename)
+    ParseError(source, stream.diagnostics)
+end
+
 function Base.showerror(io::IO, err::ParseError, bt; backtrace=false)
     println(io, "ParseError:")
     show_diagnostics(io, err.diagnostics, err.source)
@@ -156,8 +161,7 @@ function parseall(::Type{T}, input...; rule=:toplevel, version=VERSION,
         emit_diagnostic(stream, error="unexpected text after parsing $rule")
     end
     if any_error(stream.diagnostics)
-        source = SourceFile(sourcetext(stream, steal_textbuf=true), filename=filename)
-        throw(ParseError(source, stream.diagnostics))
+        throw(ParseError(stream, filename=filename))
     end
     # TODO: Figure out a more satisfying solution to the wrap_toplevel_as_kind
     # mess that we've got here.

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -120,6 +120,9 @@ children(node::SyntaxNode) = haschildren(node) ? node.val::Vector{SyntaxNode} : 
 
 span(node::SyntaxNode) = span(node.raw)
 
+first_byte(node::SyntaxNode) = node.position
+last_byte(node::SyntaxNode)  = node.position + span(node) - 1
+
 """
     sourcetext(node)
 
@@ -138,7 +141,7 @@ end
 function _show_syntax_node(io, current_filename, node::SyntaxNode, indent)
     fname = node.source.filename
     line, col = source_location(node.source, node.position)
-    posstr = "$(lpad(line, 4)):$(rpad(col,3))│$(lpad(node.position,6)):$(rpad(node.position+span(node)-1,6))│"
+    posstr = "$(lpad(line, 4)):$(rpad(col,3))│$(lpad(first_byte(node),6)):$(rpad(last_byte(node),6))│"
     val = node.val
     nodestr = haschildren(node) ? "[$(untokenize(head(node)))]" :
               isa(val, Symbol) ? string(val) : repr(val)


### PR DESCRIPTION
This allows REPL completion to work correctly. It works by pattern matching the parse tree, rather than hard coding incomplete expression detection into the parser itself.

This took a while because I got distracted with #88. Though doing some of those things first helped make this quite a lot cleaner. There's still more changes from #88 which would help make this nicer but for now it works.

The tests here are somewhat derived from `Base`, but I had to review them all (ie the tests pasted in https://github.com/JuliaLang/JuliaSyntax.jl/pull/71#issuecomment-1225364445) because they turn out to not really make sense.  For example, `"begin;"` and `"begin"` are both the prefix of a block construct, one of them shouldn't come out as `:other`.

Alternative to #71, CC @aviatesk :-)

Fix #42, would close #71