### PR TITLE
Parse keyword args with `=` head rather than `kw`

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -875,7 +875,6 @@ const _kind_names =
         "string"         # A string interior node (possibly containing interpolations)
         "cmdstring"      # A cmd string node (containing delimiters plus string)
         "macrocall"
-        "kw"             # the = in f(a=1)
         "parameters"     # the list after ; in f(; a=1)
         "toplevel"
         "tuple"


### PR DESCRIPTION
For Expr there's various cases where = is parsed into a kw head, but this is inconsistent especially when named tuples come into play. That is, the `=` parses to different heads:
* as `=`  in `(a=1, b=2)`
* as `kw` in `f(a=1, b=2)`

This causes extra complexity in the parser, and is visually confusing for macro writers. Instead, this change always parses `=` to the K"=" head, converting to the :kw head when lowering to Expr.

This all seems to work fairly well, with one fairly obscure but awkward exception - in infix notation such as `(x = 1) != y` the `=` is assignment, not a keyword argument.

Close #99 