### PR TITLE
Stricter parsing of exception names in `catch $excname`

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -157,7 +157,7 @@ function _core_parser_hook(code, filename, lineno, offset, options)
                 return Core.svec(nothing, last_byte(stream))
             end
         end
-        JuliaSyntax.parse(stream; rule=rule)
+        parse(stream; rule=rule)
         if rule === :statement
             bump_trivia(stream)
         end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2154,7 +2154,12 @@ function parse_catch(ps::ParseState)
     else
         # try x catch e y end   ==>  (try (block x) e (block y) false false)
         # try x catch $e y end  ==>  (try (block x) ($ e) (block y) false false)
-        parse_identifier_or_interpolate(ps)
+        mark = position(ps)
+        parse_eq_star(ps)
+        if !(peek_behind(ps).kind in KSet"Identifier $")
+            # try x catch e+3 y end  ==>  (try (block x) (error (call-i e + 3)) (block y) false false)
+            emit(ps, mark, K"error", error="a variable name is expected after `catch`")
+        end
     end
     parse_block(ps)
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -475,6 +475,7 @@ tests = [
         "try x catch \n y end"  =>  "(try (block x) false (block y) false false)"
         "try x catch e y end"   =>  "(try (block x) e (block y) false false)"
         "try x catch \$e y end" =>  "(try (block x) (\$ e) (block y) false false)"
+        "try x catch e+3 y end" =>  "(try (block x) (error (call-i e + 3)) (block y) false false)"
         "try x finally y end"   =>  "(try (block x) false false false (block y))"
         # v1.8 only
         ((v=v"1.8",), "try catch ; else end") => "(try (block) false (block) (block) false)"


### PR DESCRIPTION
Fix #105
