### PR TITLE
Split char delimiters early and emit K"char" node

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,9 @@ parsing `key=val` pairs inside parentheses.
   :([(x, y) for $(Expr(:filter, :(y < x), :(x = 1:10), :(y = 1:10)))])
   ```
 
+* The character `'` may be written without escaping as `'''` rather than
+  requiring the form `'\''`.
+
 # Comparisons to other packages
 
 ### Official Julia compiler

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -239,6 +239,9 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
     elseif headsym == :do
         @check length(args) == 3
         return Expr(:do, args[1], Expr(:->, args[2], args[3]))
+    elseif headsym == :char
+        @check length(args) == 1
+        return args[1]
     end
     return Expr(headsym, args...)
 end

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -42,9 +42,6 @@ function _incomplete_tag(n::SyntaxNode)
         k1 = kind(cs[1])
         if k1 == K"ErrorEofMultiComment"
             return :comment
-        elseif k1 == K"ErrorEofChar"
-            # TODO: Make this case into an internal node
-            return :char
         end
         for cc in cs
             if kind(cc) == K"error"
@@ -57,6 +54,8 @@ function _incomplete_tag(n::SyntaxNode)
         return :string
     elseif kp == K"cmdstring"
         return :cmd
+    elseif kp == K"char"
+        return :char
     elseif kp in KSet"block quote let try"
         return :block
     elseif kp in KSet"for while function if"

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -15,7 +15,6 @@ const _kind_names =
     "BEGIN_ERRORS"
         # Tokenization errors
         "ErrorEofMultiComment"
-        "ErrorEofChar"
         "ErrorInvalidNumericConstant"
         "ErrorInvalidOperator"
         "ErrorInvalidInterpolationTerminator"
@@ -874,6 +873,7 @@ const _kind_names =
         "inert"          # QuoteNode; not quasiquote
         "string"         # A string interior node (possibly containing interpolations)
         "cmdstring"      # A cmd string node (containing delimiters plus string)
+        "char"           # A char string node (containing delims + char data)
         "macrocall"
         "parameters"     # the list after ; in f(; a=1)
         "toplevel"
@@ -1004,7 +1004,6 @@ const _nonunique_kind_names = Set([
     K"Identifier"
 
     K"ErrorEofMultiComment"
-    K"ErrorEofChar"
     K"ErrorInvalidNumericConstant"
     K"ErrorInvalidOperator"
     K"ErrorInvalidInterpolationTerminator"

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -37,10 +37,10 @@ function SyntaxNode(source::SourceFile, raw::GreenNode{SyntaxHead}, position::In
             false
         elseif k == K"Char"
             v, err, _ = unescape_julia_string(val_str, false, false)
-            if err
+            if err || length(v) != 1
                 ErrorVal()
             else
-                v[2]
+                only(v)
             end
         elseif k == K"Identifier"
             if has_flags(head(raw), RAW_STRING_FLAG)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -157,6 +157,14 @@
             Expr(:string, "a\n", :x, "\nb\nc")
     end
 
+    @testset "Char conversions" begin
+        @test parse(Expr, "'a'") == 'a'
+        @test parse(Expr, "'α'") == 'α'
+        @test parse(Expr, "'\\xce\\xb1'") == 'α'
+        # FIXME
+        # @test_throws ParseError parse(Expr, "'abcde'")
+    end
+
     @testset "do block conversion" begin
         @test parse(Expr, "f(x) do y\n body end") ==
             Expr(:do, Expr(:call, :f, :x),

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -567,6 +567,14 @@ tests = [
         "(1:2)" => "(call-i 1 : 2)"
     ],
     JuliaSyntax.parse_atom => [
+        # char literal
+        "'a'"           =>  "(char 'a')"
+        "'α'"           =>  "(char 'α')"
+        "'\\xce\\xb1'"  =>  "(char 'α')"
+        "'a"            =>  "(char 'a' (error-t))"
+        "''"            =>  "(char (error))"
+        "'"             =>  "(char (error))"
+        # symbol/expression quote
         ":foo"   => "(quote foo)"
         # Literal colons
         ":)"     => ":"


### PR DESCRIPTION
Here we split off char delimiters in the tokenizer rather than re-parsing them later during value conversion. Also add a K"char" internal node to cover the delimiters and the literal char content in the green tree.

This allows us to remove another special case token error kind (ErrorEofChar) and makes char representation in the tree similar to string representation.

Part of #88 and helps with #110