### PR TITLE
Always emit a block for `let` binding lists

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -243,6 +243,16 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
     elseif headsym == :char
         @check length(args) == 1
         return args[1]
+    elseif headsym == :let
+        @check Meta.isexpr(args[1], :block)
+        a1 = args[1].args
+        # Ugly logic to strip the Expr(:block) in certian cases for compatibility
+        if length(a1) == 1
+            a = a1[1]
+            if a isa Symbol || Meta.isexpr(a, (:(=), :(::)))
+                args[1] = a
+            end
+        end
     end
     return Expr(headsym, args...)
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -357,15 +357,15 @@ tests = [
         "for x in xs end" => "(for (= x xs) (block))"
         "for x in xs, y in ys \n a \n end" => "(for (block (= x xs) (= y ys)) (block a))"
         # let
-        "let x=1\n end"    =>  "(let (= x 1) (block))"
-        "let x ; end"      =>  "(let x (block))"
-        "let x=1 ; end"    =>  "(let (= x 1) (block))"
-        "let x::1 ; end"   =>  "(let (:: x 1) (block))"
-        "let x=1,y=2 end"  =>  "(let (block (= x 1) (= y 2)) (block))"
-        "let x+=1 ; end"   =>  "(let (block (+= x 1)) (block))"
-        "let ; end"        =>  "(let (block) (block))"
-        "let ; body end"   =>  "(let (block) (block body))"
-        "let\na\nb\nend"   =>  "(let (block) (block a b))"
+        "let x=1\n end"    =>  "(let (block (= x 1)) (block))"  => Expr(:let, Expr(:(=), :x, 1),  Expr(:block))
+        "let x=1 ; end"    =>  "(let (block (= x 1)) (block))"  => Expr(:let, Expr(:(=), :x, 1),  Expr(:block))
+        "let x ; end"      =>  "(let (block x) (block))"        => Expr(:let, :x,                 Expr(:block))
+        "let x::1 ; end"   =>  "(let (block (:: x 1)) (block))" => Expr(:let, Expr(:(::), :x, 1), Expr(:block))
+        "let x=1,y=2 end"  =>  "(let (block (= x 1) (= y 2)) (block))" => Expr(:let, Expr(:block, Expr(:(=), :x, 1), Expr(:(=), :y, 2)), Expr(:block))
+        "let x+=1 ; end"   =>  "(let (block (+= x 1)) (block))" => Expr(:let, Expr(:block, Expr(:+=, :x, 1)), Expr(:block))
+        "let ; end"        =>  "(let (block) (block))"          => Expr(:let, Expr(:block), Expr(:block))
+        "let ; body end"   =>  "(let (block) (block body))"     => Expr(:let, Expr(:block), Expr(:block, :body))
+        "let\na\nb\nend"   =>  "(let (block) (block a b))"      => Expr(:let, Expr(:block), Expr(:block, :a, :b))
         # abstract type
         "abstract type A end"            =>  "(abstract A)"
         "abstract type A ; end"          =>  "(abstract A)"


### PR DESCRIPTION
This moves the unnecessary special cases for lists of bindings in `let` out of the parser and into Expr lowering.

Part of #88 