### PR TITLE
Fix const struct field errors + cleanup `global const` AST

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -253,6 +253,12 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
                 args[1] = a
             end
         end
+    elseif headsym == :local || headsym == :global
+        if length(args) == 1 && Meta.isexpr(args[1], :const)
+            # Normalize `local const` to `const local`
+            args[1] = Expr(headsym, args[1].args...)
+            headsym = :const
+        end
     end
     return Expr(headsym, args...)
 end


### PR DESCRIPTION
Here I've replicated the fix from JuliaLang/julia#45024 so that `const x` (ie, without an assignment) is only valid within a `struct` and is otherwise an error.

Also avoid lowering the syntax `global const` into `const global` within the parser; do this in Expr conversion instead. This more closely reflects the structure of the source, allowing trivia attachment to be more natural. Part of #88

Fix #129.