### PR TITLE
Permit parens in function call signatures

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -880,6 +880,7 @@ const _kind_names =
         "tuple"
         "ref"
         "vect"
+        "parens"
         # Concatenation syntax
         "braces"
         "bracescat"

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -444,13 +444,16 @@ tests = [
         "global const x" => "(global (error (const x)))"
         "const global x" => "(error (const (global x)))"
     ],
-    JuliaSyntax.parse_function => [
+    JuliaSyntax.parse_resword => [
+        # Macros and functions
         "macro while(ex) end"  =>  "(macro (call (error while) ex) (block))"
         "macro f()     end"    =>  "(macro (call f) (block))"
         "macro (:)(ex) end"    =>  "(macro (call : ex) (block))"
         "macro (type)(ex) end" =>  "(macro (call type ex) (block))"
         "macro \$f()    end"   =>  "(macro (call (\$ f)) (block))"
         "macro (\$f)()  end"   =>  "(macro (call (\$ f)) (block))"
+        "function (f() where T) end" => "(function (where (call f) T) (block))" => Expr(:function, Expr(:where, Expr(:call, :f), :T), Expr(:block))
+        "function (f()::S) end"=>  "(function (:: (call f) S) (block))"         => Expr(:function, Expr(:(::), Expr(:call, :f), :S), Expr(:block))
         "function (x) body end"=>  "(function (tuple x) (block body))"
         "function (x,y) end"   =>  "(function (tuple x y) (block))"
         "function (x=1) end"   =>  "(function (tuple (= x 1)) (block))"


### PR DESCRIPTION
This permits the extra parentheses in things like

    function (funcname(some, long, argument, list)
              where {Type,Params})
        body
    end

This syntax "works" in the reference parser and has been seen in the wild so we need to support it for compatibility. (However, it's broken when combined with return type annotations which suggests it's more a syntactic aberration rather than an intentional feature.)

Fix #116