### PR TITLE
Fix for parsing `end` in `A[x ? y : end]`

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -66,6 +66,7 @@ tests = [
         "a ? b: c"    => "(? a b (error-t) c)"
         "a ? b :c"    => "(? a b (error-t) c)"
         "a ? b c"     => "(? a b (error-t) c)"
+        "A[x ? y : end]" => "(ref A (? x y end))"
     ],
     JuliaSyntax.parse_arrow => [
         "x → y"     =>  "(call-i x → y)"


### PR DESCRIPTION
Failure due to overeager error detection of `end` keyword.

Part of #134

CC @pfitzseb 