### PR TITLE
Fix parsing of `[a~b]`

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -562,7 +562,7 @@ function parse_assignment_with_initial_ex(ps::ParseState, mark, down::T) where {
         return
     end
     if k == K"~"
-        if ps.space_sensitive && !preceding_whitespace(peek_token(ps, 2))
+        if ps.space_sensitive && preceding_whitespace(t) && !preceding_whitespace(peek_token(ps, 2))
             # Unary ~ in space sensitive context is not assignment precedence
             # [a ~b]  ==>  (hcat a (call-pre ~ b))
             return
@@ -570,6 +570,7 @@ function parse_assignment_with_initial_ex(ps::ParseState, mark, down::T) where {
         # ~ is the only non-syntactic assignment-precedence operator.
         # a ~ b      ==>  (call-i a ~ b)
         # [a ~ b c]  ==>  (hcat (call-i a ~ b) c)
+        # [a~b]      ==>  (vect (call-i a ~ b))
         bump(ps)
         parse_assignment(ps, down)
         emit(ps, mark, K"call", INFIX_FLAG)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -51,6 +51,7 @@ tests = [
         "[a ~b]"      =>  "(hcat a (call-pre ~ b))"
         "a ~ b"       =>  "(call-i a ~ b)"
         "[a ~ b c]"   =>  "(hcat (call-i a ~ b) c)"
+        "[a~b]"       =>  "(vect (call-i a ~ b))"
     ],
     JuliaSyntax.parse_pair => [
         "a => b"  =>  "(call-i a => b)"


### PR DESCRIPTION
In space sensitive contexts, `~` is parsed as unary or binary depending on whitespace to the left and right of the `~`. In this case it should be binary and parse as `(ref (call-i ~ a b))`