### PR TITLE
Lower `@ .` to `@ __dot__` not in parser but in `Expr` conversion

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -152,6 +152,9 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
     loc = source_location(LineNumberNode, node.source, node.position)
     if headsym == :macrocall
         insert!(args, 2, loc)
+        if args[1] == Symbol("@.")
+            args[1] = Symbol("@__dot__")
+        end
     elseif headsym in (:call, :ref)
         # Julia's standard `Expr` ASTs have children stored in a canonical
         # order which is often not always source order. We permute the children

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -852,7 +852,6 @@ const _kind_names =
         # like CORE_DOC_MACRO_NAME)
         "BEGIN_MACRO_NAMES"
             "MacroName"
-            "@."
             "StringMacroName"
             "CmdMacroName"
             "core_@doc"

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -74,8 +74,6 @@ function SyntaxNode(source::SourceFile, raw::GreenNode{SyntaxHead}, position::In
             nothing
         elseif k == K"error"
             ErrorVal()
-        elseif k == K"@."
-            :var"@__dot__"
         elseif k == K"MacroName"
             Symbol("@$(normalize_identifier(val_str))")
         elseif k == K"StringMacroName"

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -315,7 +315,6 @@ tests = [
         "A.B.@x"    =>  "(macrocall (. (. A (quote B)) (quote @x)))"
         "@A.B.x"    =>  "(macrocall (. (. A (quote B)) (quote @x)))"
         "A.@B.x"    =>  "(macrocall (. (. A (quote B)) (error-t) (quote @x)))"
-        "@. y"      =>  "(macrocall @__dot__ y)"
         "f.(a,b)"   =>  "(. f (tuple a b))"
         "f.(a=1; b=2)" => "(. f (tuple (= a 1) (parameters (= b 2))))" =>
             Expr(:., :f, Expr(:tuple, Expr(:parameters, Expr(:kw, :b, 2)), Expr(:kw, :a, 1)))
@@ -710,7 +709,7 @@ tests = [
         # Macro names can be keywords
         "@end x" => "(macrocall @end x)"
         # __dot__ macro
-        "@. x y" => "(macrocall @__dot__ x y)"
+        "@. x" => "(macrocall @. x)" => Expr(:macrocall, Symbol("@__dot__"), LineNumberNode(1), :x)
         # cmd strings
         "``"         =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-r \"\"))"
         "`cmd`"      =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-r \"cmd\"))"


### PR DESCRIPTION
The reason to use `__dot__` is to allow `macro __dot__` to be defined in normal Julia source. But doing this in the parser is an awkward special case - better to do it later during some lowering step.  Here done in `Expr` conversion.