### PR TITLE
Report bad macro names more clearly

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -186,6 +186,9 @@ function _core_parser_hook(code, filename, lineno, offset, options)
             end
             ex = options === :all ? Expr(:toplevel, error_ex) : error_ex
         else
+            # FIXME: Unilaterally showing any warnings to stdout here is far
+            # from ideal. But Meta.parse() has no API for communicating this.
+            show_diagnostics(stdout, stream.diagnostics, code)
             # FIXME: Add support to lineno to this tree build (via SourceFile?)
             ex = build_tree(Expr, stream; filename=filename, wrap_toplevel_as_kind=K"None")
             if Meta.isexpr(ex, :None)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -261,6 +261,7 @@ tests = [
         "@! x"  => "(macrocall @! x)"
         "@.. x" => "(macrocall @.. x)"
         "@\$ y"  => "(macrocall @\$ y)"
+        "@[x] y z" => "(macrocall (error (vect x)) y z)"
         # Special @doc parsing rules
         "@doc x\ny"    =>  "(macrocall @doc x y)"
         "A.@doc x\ny"  =>  "(macrocall (. A (quote @doc)) x y)"
@@ -326,6 +327,7 @@ tests = [
         "f.\$x"     =>  "(. f (inert (\$ x)))"
         "f.\$(x+y)" =>  "(. f (inert (\$ (call-i x + y))))"
         "A.\$B.@x"  =>  "(macrocall (. (. A (inert (\$ B))) (quote @x)))"
+        "@A.\$x a"  =>  "(macrocall (. A (inert (error x))) a)"
         "A.@x"      =>  "(macrocall (. A (quote @x)))"
         "A.@x a"    =>  "(macrocall (. A (quote @x)) a)"
         "@A.B.@x a" =>  "(macrocall (. (. A (quote B)) (quote (error-t) @x)) a)"


### PR DESCRIPTION
This change prevents a crash for various cases of bad syntax involving macro names. In particular things like `@[x] a` and `@A.x a`.

The latter case where the @ is separated from the actual macro name is a pain to deal with and is only approximately correct in this PR. But I'm not sure why we even support this syntax and maybe we could warn about it or deprecate it. So unclear whether going to greater lengths emitting K"TOMBSTONE" to be precise about error reporting in that case is worth it.