### PR TITLE
Experiment: Playing with currying, chaining and underscores

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -11,6 +11,22 @@ function is_stringchunk(node)
     return k == K"String" || k == K"CmdString"
 end
 
+function lower_underscores(args, skiparg=-1)
+    g = nothing
+    for i in 1:length(args)
+        if i == skiparg
+            continue
+        end
+        if args[i] == :_
+            if isnothing(g)
+                g = gensym()
+            end
+            args[i] = g
+        end
+    end
+    return g
+end
+
 function reorder_parameters!(args, params_pos)
     p = 0
     for i = length(args):-1:1
@@ -125,7 +141,7 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
         args[2] = _to_expr(node_args[2])
     else
         eq_to_kw_in_call =
-            headsym == :call && is_prefix_call(node)          ||
+            (headsym == :call || headsym == Symbol("/>")) && is_prefix_call(node)          ||
             headsym == :ref
         eq_to_kw_all = headsym == :parameters && !inside_vect_or_braces ||
                       (headsym == :tuple && inside_dot_expr)
@@ -168,7 +184,16 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
             headsym = Symbol("'")
         end
         # Move parameters blocks to args[2]
+        g = lower_underscores(args, 1)
         reorder_parameters!(args, 2)
+        if !isnothing(g)
+            return Expr(:->, g, Expr(:call, args...))
+        end
+    elseif headsym == :.
+        g = lower_underscores(args)
+        if !isnothing(g)
+            return Expr(:->, g, Expr(:., args...))
+        end
     elseif headsym in (:tuple, :vect, :braces)
         # Move parameters blocks to args[1]
         reorder_parameters!(args, 1)
@@ -278,9 +303,24 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
             args[1] = Expr(headsym, args[1].args...)
             headsym = :const
         end
+    elseif headsym == Symbol("/>")
+        freearg = gensym()
+        cargs = [args[1], freearg, args[2:end]...]
+        reorder_parameters!(cargs, 2)
+        return Expr(:->, freearg, Expr(:call, cargs...))
+    elseif headsym == Symbol("\\>")
+        freearg = gensym()
+        cargs = [args[1], args[2:end]..., freearg]
+        reorder_parameters!(cargs, 2)
+        return Expr(:->, freearg, Expr(:call, cargs...))
+    elseif headsym == :chain
+        return Expr(:call, :(JuliaSyntax.chain), args...)
     end
     return Expr(headsym, args...)
 end
+
+chain(x, f, fs...) = chain(f(x), fs...)
+chain(x) = x
 
 Base.Expr(node::SyntaxNode) = _to_expr(node)
 

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -813,6 +813,8 @@ const _kind_names =
     "'"
     ".'"
     "->"
+    "/>"
+    "\\>"
 
     "BEGIN_UNICODE_OPS"
         "¬"
@@ -867,6 +869,7 @@ const _kind_names =
     "BEGIN_SYNTAX_KINDS"
         "block"
         "call"
+        "chain"
         "comparison"
         "curly"
         "inert"          # QuoteNode; not quasiquote

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -793,7 +793,29 @@ end
 # x |> y |> z  ==>  (call-i (call-i x |> y) |> z)
 # flisp: parse-pipe>
 function parse_pipe_gt(ps::ParseState)
-    parse_LtoR(ps, parse_range, is_prec_pipe_gt)
+    parse_LtoR(ps, parse_curry_chain, is_prec_pipe_gt)
+end
+
+# x /> f(y) /> g(z)  ==>  (chain x (/> f y) (/> g z))
+# x /> A.f(y)        ==>  (chain x (/> (. A (quote f)) y))
+function parse_curry_chain(ps::ParseState)
+    mark = position(ps)
+    parse_range(ps)
+    has_chain = false
+    while (k = peek(ps); k == K"/>" || k == K"\>")
+        bump(ps, TRIVIA_FLAG)
+        m = position(ps)
+        parse_range(ps)
+        if peek_behind(ps).kind == K"call"
+            has_chain = true
+            reset_node!(ps, position(ps), kind=k)
+        else
+            emit(ps, m, K"error", error="Expected call to the right of />")
+        end
+    end
+    if has_chain
+        emit(ps, mark, K"chain")
+    end
 end
 
 # parse ranges and postfix ...

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -937,6 +937,8 @@ function lex_forwardslash(l::Lexer)
         end
     elseif accept(l, '=')
         return emit(l, K"/=")
+    elseif accept(l, '>')
+        return emit(l, K"/>")
     else
         return emit(l, K"/")
     end
@@ -945,6 +947,8 @@ end
 function lex_backslash(l::Lexer)
     if accept(l, '=')
         return emit(l, K"\=")
+    elseif accept(l, '>')
+        return emit(l, K"\>")
     end
     return emit(l, K"\\")
 end


### PR DESCRIPTION
A super hacky, quick implementation of some ideas from

https://discourse.julialang.org/t/fixing-the-piping-chaining-issue

Parse chains of `/>` and `\>` at the rough same precedence as `|>`, but treat them as a "frontfix/backfix operator" for function calls such that the succeeding function call becomes curried in first or last argument. Thus, the following

    x  />  f(y)  \>  g(z)

is parsed as

    (chain x (/> f y) (\> g z))

and lowered to the equivalent of

    chain(x, a->f(a, y), b->g(z, b))

Also add lowering of underscore as strictly tight-binding placeholder syntax. (Super hacky - more forms should be allowed! This is just for experimentation).

--- 

Note, I don't really expect to ever merge this, given how difficult https://github.com/JuliaLang/julia/pull/24990 has proven :grimacing: 

It's just an experiment for people to play with.

You can try this by checking out this branch and using

```
JuliaSyntax.enable_in_core!(freeze_world_age=false)
```

(With this setup, you can also edit JuliaSyntax.jl to play with different lowering scenarios and see them almost immediately in the REPL using Revise.  (May need to run a command twice for Revise to pick things up.))