### PR TITLE
Validate literals at parse time

### DIFF
--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -121,6 +121,11 @@ function show_diagnostics(io::IO, diagnostics::AbstractVector{Diagnostic}, text:
     end
 end
 
+function emit_diagnostic(diagnostics::AbstractVector{Diagnostic},
+                         fbyte::Integer, lbyte::Integer; kws...)
+    push!(diagnostics, Diagnostic(fbyte, lbyte; kws...))
+end
+
 function any_error(diagnostics::AbstractVector{Diagnostic})
     any(is_error(d) for d in diagnostics)
 end

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -186,9 +186,13 @@ function _core_parser_hook(code, filename, lineno, offset, options)
             end
             ex = options === :all ? Expr(:toplevel, error_ex) : error_ex
         else
-            # FIXME: Unilaterally showing any warnings to stdout here is far
-            # from ideal. But Meta.parse() has no API for communicating this.
-            show_diagnostics(stdout, stream.diagnostics, code)
+            # TODO: Figure out a way to show warnings. Meta.parse() has no API
+            # to communicate this, and we also can't show them to stdout as
+            # this is too side-effectful and can result in double-reporting in
+            # the REPL.
+            #
+            # show_diagnostics(stdout, stream.diagnostics, code)
+            #
             # FIXME: Add support to lineno to this tree build (via SourceFile?)
             ex = build_tree(Expr, stream; filename=filename, wrap_toplevel_as_kind=K"None")
             if Meta.isexpr(ex, :None)

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -71,6 +71,7 @@ const _kind_names =
         "HexInt"
         "OctInt"
         "Float"
+        "Float32"
         "String"
         "Char"
         "CmdString"
@@ -1015,6 +1016,7 @@ const _nonunique_kind_names = Set([
     K"HexInt"
     K"OctInt"
     K"Float"
+    K"Float32"
     K"String"
     K"Char"
     K"CmdString"
@@ -1088,7 +1090,7 @@ is_syntax_kind(x)      = K"BEGIN_SYNTAX_KINDS" < kind(x) < K"END_SYNTAX_KINDS"
 is_macro_name(x)       = K"BEGIN_MACRO_NAMES" < kind(x) < K"END_MACRO_NAMES"
 
 function is_number(x)
-    kind(x) in (K"Integer", K"BinInt", K"HexInt", K"OctInt", K"Float")
+    kind(x) in (K"Integer", K"BinInt", K"HexInt", K"OctInt", K"Float", K"Float32")
 end
 
 function is_string_delim(x)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1120,7 +1120,7 @@ function parse_unary(ps::ParseState)
     end
     if k in KSet"- +" && !is_decorated(t)
         t2 = peek_token(ps, 2)
-        if !preceding_whitespace(t2) && kind(t2) in KSet"Integer Float"
+        if !preceding_whitespace(t2) && kind(t2) in KSet"Integer Float Float32"
             k3 = peek(ps, 3)
             if is_prec_power(k3) || k3 in KSet"[ {"
                 # `[`, `{` (issue #18851) and `^` have higher precedence than
@@ -1133,9 +1133,10 @@ function parse_unary(ps::ParseState)
             else
                 # We have a signed numeric literal. Glue the operator to the
                 # next token to create a signed literal:
-                # -2    ==>  -2
-                # +2.0  ==>  2.0
-                # -2*x  ==>  (call-i -2 * x)
+                # -2      ==>  -2
+                # +2.0    ==>  2.0
+                # -1.0f0  ==>  -1.0f0
+                # -2*x    ==>  (call-i -2 * x)
                 bump_glue(ps, kind(t2), EMPTY_FLAGS, 2)
             end
             return

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -51,6 +51,7 @@ function parse!(stream::ParseStream; rule::Symbol=:toplevel)
     else
         throw(ArgumentError("Unknown grammar rule $rule"))
     end
+    validate_literal_tokens(stream)
     stream
 end
 

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -801,7 +801,7 @@ function lex_digit(l::Lexer, kind)
         accept_number(l, isdigit)
         pc, ppc = dpeekchar(l)
         if (pc == 'e' || pc == 'E' || pc == 'f') && (isdigit(ppc) || ppc == '+' || ppc == '-' || ppc == '−')
-            kind = K"Float"
+            kind = pc == 'f' ? K"Float32" : K"Float"
             readchar(l)
             accept(l, "+-−")
             if accept_batch(l, isdigit)
@@ -819,7 +819,7 @@ function lex_digit(l::Lexer, kind)
         end
 
     elseif (pc == 'e' || pc == 'E' || pc == 'f') && (isdigit(ppc) || ppc == '+' || ppc == '-' || ppc == '−')
-        kind = K"Float"
+        kind = pc == 'f' ? K"Float32" : K"Float"
         readchar(l)
         accept(l, "+-−")
         if accept_batch(l, isdigit)

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -1,0 +1,54 @@
+function diagnostic(str; allow_multiple=false)
+    stream = ParseStream(str)
+    parse!(stream)
+    if allow_multiple
+        stream.diagnostics
+    else
+        @test length(stream.diagnostics) == 1
+        only(stream.diagnostics)
+    end
+end
+
+@testset "diagnostics for literal parsing" begin
+    # Float overflow/underflow
+    @test diagnostic("x = 10.0e1000;") ==
+        Diagnostic(5, 13, :error, "overflow in floating point literal")
+    @test diagnostic("x = 10.0f1000;") ==
+        Diagnostic(5, 13, :error, "overflow in floating point literal")
+    @test diagnostic("x = 10.0e-1000;") ==
+        Diagnostic(5, 14, :warning, "underflow in floating point literal")
+    @test diagnostic("x = 10.0f-1000;") ==
+        Diagnostic(5, 14, :warning, "underflow in floating point literal")
+
+    # Char
+    @test diagnostic("x = ''") ==
+        Diagnostic(6, 5, :error, "empty character literal")
+    @test diagnostic("x = 'abc'") ==
+        Diagnostic(6, 8, :error, "character literal contains multiple characters")
+    @test diagnostic("x = '\\xq'") ==
+        Diagnostic(6, 7, :error, "invalid hex escape sequence")
+    @test diagnostic("x = '\\uq'") ==
+        Diagnostic(6, 7, :error, "invalid unicode escape sequence")
+    @test diagnostic("x = '\\Uq'") ==
+        Diagnostic(6, 7, :error, "invalid unicode escape sequence")
+    @test diagnostic("x = '\\777'") ==
+        Diagnostic(6, 9, :error, "invalid octal escape sequence")
+    @test diagnostic("x = '\\k'") ==
+        Diagnostic(6, 7, :error, "invalid escape sequence")
+
+    # String
+    @test diagnostic("x = \"abc\\xq\"") ==
+        Diagnostic(9, 10, :error, "invalid hex escape sequence")
+    @test diagnostic("x = \"abc\\uq\"") ==
+        Diagnostic(9, 10, :error, "invalid unicode escape sequence")
+    @test diagnostic("x = \"abc\\Uq\"") ==
+        Diagnostic(9, 10, :error, "invalid unicode escape sequence")
+    @test diagnostic("x = \"abc\\777\"") ==
+        Diagnostic(9, 12, :error, "invalid octal escape sequence")
+    @test diagnostic("x = \"abc\\k\"") ==
+        Diagnostic(9, 10, :error, "invalid escape sequence")
+    @test diagnostic("x = \"abc\\k \\k\"", allow_multiple=true) == [
+        Diagnostic(9, 10, :error, "invalid escape sequence"),
+        Diagnostic(12, 13, :error, "invalid escape sequence")
+    ]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ end
 include("test_utils.jl")
 include("parse_stream.jl")
 include("parser.jl")
+include("diagnostics.jl")
 include("parser_api.jl")
 include("expr.jl")
 @testset "Parsing values from strings" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -5,6 +5,7 @@ using .JuliaSyntax:
     # Parsing
     ParseStream,
     ParseState,
+    Diagnostic,
     SourceFile,
     parse!,
     parse,
@@ -226,6 +227,7 @@ for debugging.
 function itest_parse(production, code; version::VersionNumber=v"1.6")
     stream = ParseStream(code; version=version)
     production(JuliaSyntax.ParseState(stream))
+    JuliaSyntax.validate_literal_tokens(stream)
     t = JuliaSyntax.build_tree(GreenNode, stream, wrap_toplevel_as_kind=K"toplevel")
 
     println(stdout, "# Code:\n$code\n")

--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -580,7 +580,7 @@ end
     @test toks(".1..")   == [".1"=>K"Float",    ".."=>K".."]
     @test toks("0x01..") == ["0x01"=>K"HexInt", ".."=>K".."]
 
-    @test kind.(collect(tokenize("1f0./1"))) == [K"Float", K"/", K"Integer", K"EndMarker"]
+    @test kind.(collect(tokenize("1f0./1"))) == [K"Float32", K"/", K"Integer", K"EndMarker"]
 end
 
 
@@ -618,15 +618,15 @@ end
     @test tok("1.0e-0").kind == K"Float"
     @test tok("1.0E0").kind  == K"Float"
     @test tok("1.0E-0").kind == K"Float"
-    @test tok("1.0f0").kind  == K"Float"
-    @test tok("1.0f-0").kind == K"Float"
+    @test tok("1.0f0").kind  == K"Float32"
+    @test tok("1.0f-0").kind == K"Float32"
 
     @test tok("0e0").kind    == K"Float"
     @test tok("0e+0").kind   == K"Float"
     @test tok("0E0").kind    == K"Float"
     @test tok("201E+0").kind == K"Float"
-    @test tok("2f+0").kind   == K"Float"
-    @test tok("2048f0").kind == K"Float"
+    @test tok("2f+0").kind   == K"Float32"
+    @test tok("2048f0").kind == K"Float32"
     @test tok("1.:0").kind == K"Float"
     @test tok("0x00p2").kind == K"Float"
     @test tok("0x00P2").kind == K"Float"
@@ -639,7 +639,7 @@ end
 
     # Floating point with \minus rather than -
     @test tok("1.0e−0").kind == K"Float"
-    @test tok("1.0f−0").kind == K"Float"
+    @test tok("1.0f−0").kind == K"Float32"
     @test tok("0x0p−2").kind == K"Float"
 end
 


### PR DESCRIPTION
Here we unconditionally validate all literals after `parse!()` - this includes processing String and Char escape sequences, and detecting numeric overflow.

Currently the way this is done up front in `parse!()` means it'll be redone later during conversion to SyntaxNode. The time cost of this in parsing to Expr seems to be about 20% in the worst case where the code consists of a large array of Float64 literals. Which isn't great but is probably acceptable.  (This rework can be avoided with extra refactoring, but requires a place to put the parsed literals and a way to recover them during tree building. Those things can probably be done in a later follow up.)

![20221116_11h57m09s_grim](https://user-images.githubusercontent.com/601473/202064641-4a3341da-e23f-438b-bbf2-7296a6db10ee.png)

fix #138
fix #109 
fix #82 
fix #67