### PR TITLE
Parse dotted calls with `dotcall` head

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -868,6 +868,7 @@ const _kind_names =
     "BEGIN_SYNTAX_KINDS"
         "block"
         "call"
+        "dotcall"
         "comparison"
         "curly"
         "inert"          # QuoteNode; not quasiquote

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -83,7 +83,7 @@ function untokenize(head::SyntaxHead; unique=true, include_flag_suff=true)
     if include_flag_suff && suffix_flags != EMPTY_FLAGS
         str = str*"-"
         is_trivia(head)  && (str = str*"t")
-        is_infix_op_call(head)          && (str = str*"i")
+        is_infix_op_call(head)   && (str = str*"i")
         is_prefix_op_call(head)  && (str = str*"pre")
         is_postfix_op_call(head) && (str = str*"post")
         has_flags(head, TRIPLE_STRING_FLAG) && (str = str*"s")
@@ -725,9 +725,7 @@ function bump_split(stream::ParseStream, split_spec...)
         push!(stream.tokens, SyntaxToken(h, kind(tok), b))
     end
     stream.peek_count = 0
-    # Returning position(stream) like the other bump* methods would be
-    # ambiguous here; return nothing instead.
-    nothing
+    return position(stream)
 end
 
 function _reset_node_head(x, k, f)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -223,4 +223,16 @@
         @test parse(Expr, "f(a .= 1)") ==
             Expr(:call, :f, Expr(:.=, :a, 1))
     end
+
+    @testset "dotcall" begin
+        parse(Expr, "f.(x,y)") == Expr(:., :f, Expr(:tuple, :x, :y))
+        parse(Expr, "f.(x=1)") == Expr(:., :f, Expr(:tuple, Expr(:kw, :x, 1)))
+        parse(Expr, "x .+ y")  == Expr(:call, Symbol(".+"), :x, :y)
+        parse(Expr, "(x=1) .+ y")  == Expr(:call, Symbol(".+"), Expr(:(=), :x, 1), :y)
+        parse(Expr, "a .< b .< c")  == Expr(:comparison, :a, Symbol(".<"),
+                                            :b, Symbol(".<"), :c)
+        parse(Expr, ".*(x)")  == Expr(:call, Symbol(".*"), :x)
+        parse(Expr, ".+(x)")  == Expr(:call, Symbol(".+"), :x)
+        parse(Expr, ".+x")    == Expr(:call, Symbol(".+"), :x)
+    end
 end


### PR DESCRIPTION
Dotted call syntax parses into various forms which aren't really consistent. Especially, Expr is inconsistent about dotted infix calls vs dotted prefix calls. In this change we adopt a more consistent (and hopefully less mysterious!) parsing where dotted calls get their own `dotcall` head which is otherwise like the `call` head:

    f.(a, b)  ==>  (dotcall f a b)
    a .+ b    ==>  (dotcall-i a + b)
    .+ b      ==>  (dotcall-pre + b)

In other cases where a dotted operator appears as an atom we split the dot from an operator, so `.+` becomes `(. +)`. Thus, for comparison chains and prefix calls, we have the following parsings:

    a .< b < c  ==>  (comparison a (. <) b < c)
    .*(a,b)     ==>  (call (. *) a b)

TODO: Unambiguously reconstructing the associated Expr in the latter cases is more challenging than expected and still requires some work.

Fix #90
Also incidentally fix #38 