### PR TITLE
Add ignore_errors keyword to main parser API

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -72,7 +72,8 @@ function parse!(::Type{TreeType}, io::IO;
 end
 
 function _parse(rule::Symbol, need_eof::Bool, ::Type{T}, text, index=1; version=VERSION,
-                ignore_trivia=true, filename=nothing, ignore_warnings=false) where {T}
+                ignore_trivia=true, filename=nothing, ignore_errors=false,
+                ignore_warnings=ignore_errors) where {T}
     stream = ParseStream(text, index; version=version)
     if ignore_trivia && rule != :toplevel
         bump_trivia(stream, skip_newlines=true)
@@ -85,7 +86,8 @@ function _parse(rule::Symbol, need_eof::Bool, ::Type{T}, text, index=1; version=
             emit_diagnostic(stream, error="unexpected text after parsing $rule")
         end
     end
-    if any_error(stream.diagnostics) || (!ignore_warnings && !isempty(stream.diagnostics))
+    if (!ignore_errors && any_error(stream.diagnostics)) ||
+          (!ignore_warnings && !isempty(stream.diagnostics))
         throw(ParseError(stream, filename=filename))
     end
     # TODO: Figure out a more satisfying solution to the wrap_toplevel_as_kind

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -80,4 +80,16 @@
         @test parseatom(Expr, SubString("x+y"), 1) == (:x, 2)
         @test parseatom(Expr, SubString("x+y"), 3) == (:y, 4)
     end
+
+    @testset "error/warning handling" begin
+        # ignore_warnings
+        parse_sexpr(s;kws...) = sprint(show, MIME("text/x.sexpression"), parse(SyntaxNode, s; kws...))
+        @test_throws JuliaSyntax.ParseError parse_sexpr("try finally catch ex end")
+        @test parse_sexpr("try finally catch ex end", ignore_warnings=true) ==
+            "(try_finally_catch (block) false false false (block) ex (block))"
+        # ignore_errors
+        @test_throws JuliaSyntax.ParseError parse_sexpr("[a; b, c]")
+        @test_throws JuliaSyntax.ParseError parse_sexpr("[a; b, c]", ignore_warnings=true)
+        @test parse_sexpr("[a; b, c]", ignore_errors=true) == "(vcat a b (error-t) c)"
+    end
 end


### PR DESCRIPTION
This allows extracting the recovered tree (containing error nodes) without using the low-level parse!() API.