### PR TITLE
Only warn when float literals underflow to zero

### DIFF
--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -16,9 +16,13 @@ end
     @test diagnostic("x = 10.0f1000;") ==
         Diagnostic(5, 13, :error, "overflow in floating point literal")
     @test diagnostic("x = 10.0e-1000;") ==
-        Diagnostic(5, 14, :warning, "underflow in floating point literal")
+        Diagnostic(5, 14, :warning, "underflow to zero in floating point literal")
     @test diagnostic("x = 10.0f-1000;") ==
-        Diagnostic(5, 14, :warning, "underflow in floating point literal")
+        Diagnostic(5, 14, :warning, "underflow to zero in floating point literal")
+    # Underflow boundary
+    @test diagnostic("5e-324", allow_multiple=true) == []
+    @test diagnostic("2e-324") ==
+        Diagnostic(1, 6, :warning, "underflow to zero in floating point literal")
 
     # Char
     @test diagnostic("x = ''") ==


### PR DESCRIPTION
`jl_strtod_c` can return "underflow" even for valid cases such as `5e-324` where the source string is parsed to an exact Float64 representation.

So we can't rely on jl_strtod_c to detect "invalid" underflow. Rather, only warn when underflowing to zero which is probably a programming mistake.