### PR TITLE
Allow + prefix to be part of unsigned numeric literals

### DIFF
--- a/src/value_parsing.jl
+++ b/src/value_parsing.jl
@@ -20,7 +20,10 @@ function parse_int_literal(str::AbstractString)
 end
 
 function parse_uint_literal(str::AbstractString, k)
-    str = replace(replace(str, '_'=>""), '−'=>'-')
+    str = replace(str, '_'=>"")
+    if startswith(str, '+')
+        str = str[2:end]
+    end
     ndigits = length(str)-2
     if k == K"HexInt"
         return ndigits <= 2  ? Base.parse(UInt8, str)   :
@@ -30,7 +33,6 @@ function parse_uint_literal(str::AbstractString, k)
                ndigits <= 32 ? Base.parse(UInt128, str) :
                Base.parse(BigInt, str)
     elseif k == K"BinInt"
-        str = replace(replace(str, '_'=>""), '−'=>'-')
         ndigits = length(str)-2
         return ndigits <= 8   ? Base.parse(UInt8, str)   :
                ndigits <= 16  ? Base.parse(UInt16, str)  :

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -177,9 +177,17 @@ tests = [
         "isa::T"   => "(:: isa T)"
         "-2^x"     => "(call-pre - (call-i 2 ^ x))"
         "-2[1, 3]" => "(call-pre - (ref 2 1 3))"
+        # signed literals
         "-2"       => "-2"
         "+2.0"     => "2.0"
         "-1.0f0"   => "-1.0f0"
+        "-0xf.0p0" => "-15.0"
+        "+0b10010" => "0x12"
+        "+0o22"    => "0x12"
+        "+0x12"    => "0x12"
+        "-0b10010" => "(call-pre - 0x12)"
+        "-0o22"    => "(call-pre - 0x12)"
+        "-0x12"    => "(call-pre - 0x12)"
         # Standalone dotted operators are parsed as (|.| op)
         ".+"   =>  "(. +)"
         ".+\n" =>  "(. +)"


### PR DESCRIPTION
So +0xff is a numeric literal, not `(call-pre + 0xff)`