### PR TITLE
Fix where parameter conversion as in `A where {X, Y; Z}`

### DIFF
--- a/test/expr.jl
+++ b/test/expr.jl
@@ -235,4 +235,8 @@
         parse(Expr, ".+(x)")  == Expr(:call, Symbol(".+"), :x)
         parse(Expr, ".+x")    == Expr(:call, Symbol(".+"), :x)
     end
+
+    @testset "where" begin
+        @test parse(Expr, "A where {X, Y; Z}") == Expr(:where, :A, Expr(:parameters, :Z), :X, :Y)
+    end
 end


### PR DESCRIPTION
This "frankenwhere" syntax is used by the SimpleTraits.jl `@traitfn` macro.