### PR TITLE
Avoid use of GlobalRef in SyntaxNode trees

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -31,7 +31,7 @@ function reorder_parameters!(args, params_pos)
 end
 
 function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
-                  eq_to_kw=false, inside_vect_or_braces=false)
+                  eq_to_kw=false, inside_vect_or_braces=false, inside_do=false)
     if !haschildren(node)
         val = node.val
         if val isa Union{Int128,UInt128,BigInt}
@@ -44,6 +44,10 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
                       val isa UInt128 ? Symbol("@uint128_str") :
                       Symbol("@big_str")
             return Expr(:macrocall, GlobalRef(Core, macname), nothing, str)
+        elseif kind(node) == K"core_@doc"
+            return GlobalRef(Core, :var"@doc")
+        elseif kind(node) == K"core_@cmd"
+            return GlobalRef(Core, :var"@cmd")
         else
             return val
         end

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -94,9 +94,9 @@ function SyntaxNode(source::SourceFile, raw::GreenNode{SyntaxHead}, position::In
         elseif k == K"CmdMacroName"
             Symbol("@$(normalize_identifier(val_str))_cmd")
         elseif k == K"core_@doc"
-            GlobalRef(Core, :var"@doc")
+            Symbol("core_@doc")
         elseif k == K"core_@cmd"
-            GlobalRef(Core, :var"@cmd")
+            Symbol("core_@cmd")
         elseif is_syntax_kind(raw)
             nothing
         else

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -38,7 +38,7 @@ tests = [
         "a;b;c"   => "(toplevel a b c)"
         "a;;;b;;" => "(toplevel a b)"
         """ "x" a ; "y" b """ =>
-            """(toplevel (macrocall :(Core.var"@doc") (string "x") a) (macrocall :(Core.var"@doc") (string "y") b))"""
+            """(toplevel (macrocall core_@doc (string "x") a) (macrocall core_@doc (string "y") b))"""
         "x y"  =>  "x (error-t y)"
     ],
     JuliaSyntax.parse_eq => [
@@ -457,7 +457,7 @@ tests = [
         "module do \n end"  =>  "(module true (error (do)) (block))"
         "module \$A end"    =>  "(module true (\$ A) (block))"
         "module A \n a \n b \n end"  =>  "(module true A (block a b))"
-        """module A \n "x"\na\n end""" => """(module true A (block (macrocall :(Core.var"@doc") (string "x") a)))"""
+        """module A \n "x"\na\n end""" => """(module true A (block (macrocall core_@doc (string "x") a)))"""
         # export
         "export a"   =>  "(export a)"  => Expr(:export, :a)
         "export @a"  =>  "(export @a)" => Expr(:export, Symbol("@a"))
@@ -750,9 +750,9 @@ tests = [
         # __dot__ macro
         "@. x" => "(macrocall @. x)" => Expr(:macrocall, Symbol("@__dot__"), LineNumberNode(1), :x)
         # cmd strings
-        "``"         =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-r \"\"))"
-        "`cmd`"      =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-r \"cmd\"))"
-        "```cmd```"  =>  "(macrocall :(Core.var\"@cmd\") (cmdstring-sr \"cmd\"))"
+        "``"         =>  "(macrocall core_@cmd (cmdstring-r \"\"))"
+        "`cmd`"      =>  "(macrocall core_@cmd (cmdstring-r \"cmd\"))"
+        "```cmd```"  =>  "(macrocall core_@cmd (cmdstring-sr \"cmd\"))"
         # literals
         "42"   => "42"
         "1.0e-1000"   => "0.0"
@@ -816,7 +816,7 @@ tests = [
         # Triple-quoted dedenting:
         "\"\"\"\nx\"\"\""   =>  raw"""(string-s "x")"""
         "\"\"\"\n\nx\"\"\"" =>  raw"""(string-s "\n" "x")"""
-        "```\n x\n y```"    =>  raw"""(macrocall :(Core.var"@cmd") (cmdstring-sr "x\n" "y"))"""
+        "```\n x\n y```"    =>  raw"""(macrocall core_@cmd (cmdstring-sr "x\n" "y"))"""
         # Various newlines (\n \r \r\n) and whitespace (' ' \t)
         "\"\"\"\n x\n y\"\"\""  =>  raw"""(string-s "x\n" "y")"""
         "\"\"\"\r x\r y\"\"\""  =>  raw"""(string-s "x\n" "y")"""
@@ -875,11 +875,11 @@ tests = [
         """ "notdoc" ]        """ => "(string \"notdoc\")"
         """ "notdoc" \n]      """ => "(string \"notdoc\")"
         """ "notdoc" \n\n foo """ => "(string \"notdoc\")"
-        """ "doc" \n foo      """ => """(macrocall :(Core.var"@doc") (string "doc") foo)"""
-        """ "doc" foo         """ => """(macrocall :(Core.var"@doc") (string "doc") foo)"""
-        """ "doc \$x" foo     """ => """(macrocall :(Core.var"@doc") (string "doc " x) foo)"""
+        """ "doc" \n foo      """ => """(macrocall core_@doc (string "doc") foo)"""
+        """ "doc" foo         """ => """(macrocall core_@doc (string "doc") foo)"""
+        """ "doc \$x" foo     """ => """(macrocall core_@doc (string "doc " x) foo)"""
         # Allow docstrings with embedded trailing whitespace trivia
-        "\"\"\"\n doc\n \"\"\" foo"  => """(macrocall :(Core.var"@doc") (string-s "doc\\n") foo)"""
+        "\"\"\"\n doc\n \"\"\" foo"  => """(macrocall core_@doc (string-s "doc\\n") foo)"""
     ],
 ]
 


### PR DESCRIPTION
This makes the tree more symbolic, by using unique SyntaxNode head types to refer to core macro names, rather than needing an explicit reference to the Core module included in the tree.