### PR TITLE
Fix an obscure form of function definition

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -31,7 +31,7 @@ function reorder_parameters!(args, params_pos)
 end
 
 function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
-                  eq_to_kw=false, inside_vect_or_braces=false, inside_do=false)
+                  eq_to_kw=false, inside_vect_or_braces=false)
     if !haschildren(node)
         val = node.val
         if val isa Union{Int128,UInt128,BigInt}

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2095,7 +2095,7 @@ function parse_function_signature(ps::ParseState, is_function::Bool)
             is_empty_tuple = peek(ps, skip_newlines=true) == K")"
             opts = parse_brackets(ps, K")") do _, _, _, _
                 _parsed_call = was_eventually_call(ps)
-                _is_anon_func = peek(ps, 2) != K"(" && !_parsed_call
+                _is_anon_func = peek(ps, 2) ∉ KSet"( ." && !_parsed_call
                 return (needs_parameters = _is_anon_func,
                         is_anon_func     = _is_anon_func,
                         parsed_call      = _parsed_call)
@@ -2115,6 +2115,7 @@ function parse_function_signature(ps::ParseState, is_function::Bool)
                 # function ()(x) end  ==> (function (call (tuple) x) (block))
                 emit(ps, mark, K"tuple")
             else
+                # function (A).f() end  ==> (function (call (. A (quote f))) (block))
                 # function (:)() end    ==> (function (call :) (block))
                 # function (x::T)() end ==> (function (call (:: x T)) (block))
                 # function (::T)() end  ==> (function (call (:: T)) (block))

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -515,6 +515,7 @@ tests = [
         "function (x=1) end"   =>  "(function (tuple (= x 1)) (block))"
         "function (;x=1) end"  =>  "(function (tuple (parameters (= x 1))) (block))"
         "function ()(x) end"   =>  "(function (call (tuple) x) (block))"
+        "function (A).f() end" =>  "(function (call (. A (quote f))) (block))"
         "function (:)() end"   =>  "(function (call :) (block))"
         "function (x::T)() end"=>  "(function (call (:: x T)) (block))"
         "function (::T)() end" =>  "(function (call (:: T)) (block))"


### PR DESCRIPTION
Fix cases where parens are used around module name such as

    function (A).f()
    end

See in the wild as things like `function ($M).$J() end`