### PR TITLE
Trailing linebreak is not significant in hcat

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2882,10 +2882,16 @@ function parse_array_separator(ps, array_order)
     k = kind(t)
     if k == K"NewlineWs"
         bump_trivia(ps)
-        # Treat a linebreak prior to a value as a semicolon (ie, separator for
-        # the first dimension) if no previous semicolons observed
-        # [a \n b]  ==> (vcat a b)
-        return (1, -1)
+        if peek(ps) == K"]"
+            # Linebreaks not significant before closing `]`
+            # [a b\n\n]  ==>  (hcat a b)
+            return (typemin(Int), typemin(Int))
+        else
+            # Treat a linebreak prior to a value as a semicolon (ie, separator
+            # for the first dimension) if no previous semicolons observed
+            # [a \n b]  ==> (vcat a b)
+            return (1, -1)
+        end
     elseif k == K","
         # Treat `,` as semicolon for the purposes of recovery
         # [a; b, c] ==> (vcat a b (error-t) c)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -799,6 +799,8 @@ tests = [
         ((v=v"1.7",), "[a b \n ;; c]")  =>  "(ncat-2 (row a b (error-t)) c)"
         # Can't mix spaces and multiple ;'s
         ((v=v"1.7",), "[a b ;; c]")  =>  "(ncat-2 (row a b (error-t)) c)"
+        # Linebreaks not significant before closing `]`
+        "[a b\n\n]" =>  "(hcat a b)"
         # Treat a linebreak prior to a value as a semicolon (ie, separator for
         # the first dimension) if no previous semicolons observed
         "[a \n b]"  =>  "(vcat a b)"


### PR DESCRIPTION
In the reference parser, `[a b\n\n]` parses as `(hcat a b)`, not vcat with a single row.

Part of #134 

On further thought, I'm not sure whether this is a bug here or in the reference parser. The behavior seems a bit inconsistent.