### PR TITLE
Improve Expr comparison code for registry testing

### DIFF
--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -31,7 +31,7 @@ Logging.with_logger(logger) do
                 @assert Meta.isexpr(e2, :toplevel)
                 try
                     e1 = JuliaSyntax.parseall(Expr, code, filename=fpath)
-                    if JuliaSyntax.remove_linenums!(e1) != JuliaSyntax.remove_linenums!(e2)
+                    if !exprs_roughly_equal(e2, e1)
                         mismatch_count += 1
                         @error("Parsers succeed but disagree",
                                fpath,


### PR DESCRIPTION
Add special cases to explicitly allow a few incompatibilities for cases where the reference parser has bugs:

* `0x1.8p23f` is a `Float64` literal, with the trailing `f` ignored (also `0x1p1f0`)
* The macrocall in `"@f(a=1) do\nend"` is not the same as the call in `@f(a=1)`
* `global (x,y)` is the same as `global x,y`
* Triple quoted indentation - `"\"\"\"\n  a\n \n  b\"\"\""` parses to "a\n \nb"

Tooling for #134 