### PR TITLE
Emit sensible errors for invalid operator tokens

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -35,14 +35,12 @@ function _incomplete_tag(n::SyntaxNode)
         return :none
     end
     # TODO: Check error hits last character
-    if kind(c) == K"error" && begin
+    if kind(c) == K"ErrorEofMultiComment"
+        return :comment
+    elseif kind(c) == K"error" && begin
                 cs = children(c)
                 length(cs) > 0
             end
-        k1 = kind(cs[1])
-        if k1 == K"ErrorEofMultiComment"
-            return :comment
-        end
         for cc in cs
             if kind(cc) == K"error"
                 return :other

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -16,8 +16,10 @@ const _kind_names =
         # Tokenization errors
         "ErrorEofMultiComment"
         "ErrorInvalidNumericConstant"
-        "ErrorInvalidOperator"
         "ErrorInvalidInterpolationTerminator"
+        "ErrorNumericOverflow"
+        "ErrorInvalidEscapeSequence"
+        "ErrorOverLongCharacter"
         # Generic error
         "error"
     "END_ERRORS"
@@ -94,6 +96,9 @@ const _kind_names =
     "END_DELIMITERS"
 
     "BEGIN_OPS"
+    "ErrorInvalidOperator"
+    "Error**"
+
     "..."
 
     # Level 1
@@ -1009,8 +1014,11 @@ const _nonunique_kind_names = Set([
 
     K"ErrorEofMultiComment"
     K"ErrorInvalidNumericConstant"
-    K"ErrorInvalidOperator"
     K"ErrorInvalidInterpolationTerminator"
+    K"ErrorNumericOverflow"
+    K"ErrorInvalidEscapeSequence"
+    K"ErrorOverLongCharacter"
+    K"ErrorInvalidOperator"
 
     K"Integer"
     K"BinInt"
@@ -1049,7 +1057,7 @@ end
 #-------------------------------------------------------------------------------
 # Predicates
 is_contextual_keyword(k::Kind) = K"BEGIN_CONTEXTUAL_KEYWORDS" < k < K"END_CONTEXTUAL_KEYWORDS"
-is_error(k::Kind) = K"BEGIN_ERRORS" < k < K"END_ERRORS"
+is_error(k::Kind) = K"BEGIN_ERRORS" < k < K"END_ERRORS" || k == K"ErrorInvalidOperator" || k == K"Error**"
 is_keyword(k::Kind) = K"BEGIN_KEYWORDS" < k < K"END_KEYWORDS"
 is_block_continuation_keyword(k::Kind) = K"BEGIN_BLOCK_CONTINUATION_KEYWORDS" < k < K"END_BLOCK_CONTINUATION_KEYWORDS"
 is_literal(k::Kind) = K"BEGIN_LITERAL" < k < K"END_LITERAL"

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -51,7 +51,7 @@ function parse!(stream::ParseStream; rule::Symbol=:toplevel)
     else
         throw(ArgumentError("Unknown grammar rule $rule"))
     end
-    validate_literal_tokens(stream)
+    validate_tokens(stream)
     stream
 end
 

--- a/src/tokenize_utils.jl
+++ b/src/tokenize_utils.jl
@@ -147,25 +147,23 @@ readchar(io::IO) = eof(io) ? EOF_CHAR : read(io, Char)
     0x0000ffe9 <= c <= 0x0000ffec
 end
 
-function dotop2(pc, dpc)
+function dotop2(pc)
     dotop1(pc) ||
     pc =='+' ||
     pc =='-' ||
+    pc =='−' ||
     pc =='*' ||
     pc =='/' ||
     pc =='\\' ||
     pc =='^' ||
     pc =='<' ||
     pc =='>' ||
-    pc =='&' && dpc === '=' ||
     pc =='&' ||
     pc =='%' ||
-    pc == '=' && dpc != '>' ||
-    pc == '|' && dpc != '|' ||
-    pc == '!' && dpc == '=' ||
+    pc == '=' ||
+    pc == '|' ||
     pc == '⊻' ||
-    pc == '÷' ||
-    pc == '=' && dpc == '>'
+    pc == '÷'
 end
 
 # suffix operators

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1,7 +1,7 @@
 function test_parse(production, code; v=v"1.6", expr=false)
     stream = ParseStream(code, version=v)
     production(ParseState(stream))
-    JuliaSyntax.validate_literal_tokens(stream)
+    JuliaSyntax.validate_tokens(stream)
     t = build_tree(GreenNode, stream, wrap_toplevel_as_kind=K"None")
     source = SourceFile(code)
     s = SyntaxNode(source, t)
@@ -126,6 +126,9 @@ tests = [
         "x..."     => "(... x)"
         "x:y..."   => "(... (call-i x : y))"
         "x..y..."  => "(... (call-i x .. y))"
+    ],
+    JuliaSyntax.parse_invalid_ops => [
+        "a--b"  =>  "(call-i a (ErrorInvalidOperator) b)"
     ],
     JuliaSyntax.parse_expr => [
         "a - b - c"  => "(call-i (call-i a - b) - c)"
@@ -870,11 +873,11 @@ tests = [
     ],
     JuliaSyntax.parse_atom => [
         # errors in literals
-        "\"\\xqqq\""  =>  "(string (error))"
-        "'ab'"        =>  "(char (error))"
-        "'\\xq'"      =>  "(char (error))"
-        "10.0e1000'"  =>  "(error)"
-        "10.0f100'"   =>  "(error)"
+        "\"\\xqqq\""  =>  "(string (ErrorInvalidEscapeSequence))"
+        "'\\xq'"      =>  "(char (ErrorInvalidEscapeSequence))"
+        "'ab'"        =>  "(char (ErrorOverLongCharacter))"
+        "10.0e1000'"  =>  "(ErrorNumericOverflow)"
+        "10.0f100'"   =>  "(ErrorNumericOverflow)"
     ],
     JuliaSyntax.parse_docstring => [
         """ "notdoc" ]        """ => "(string \"notdoc\")"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -311,7 +311,7 @@ for debugging.
 function itest_parse(production, code; version::VersionNumber=v"1.6")
     stream = ParseStream(code; version=version)
     production(JuliaSyntax.ParseState(stream))
-    JuliaSyntax.validate_literal_tokens(stream)
+    JuliaSyntax.validate_tokens(stream)
     t = JuliaSyntax.build_tree(GreenNode, stream, wrap_toplevel_as_kind=K"toplevel")
 
     println(stdout, "# Code:\n$code\n")

--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -231,6 +231,7 @@ end
 
     @test toks("#=# text=#") == ["#=# text=#"=>K"Comment"]
 
+    @test toks("#=   #=   =#") == ["#=   #=   =#"=>K"ErrorEofMultiComment"]
     @test toks("#=#==#=#") == ["#=#==#=#"=>K"Comment"]
     @test toks("#=#==#=")  == ["#=#==#="=>K"ErrorEofMultiComment"]
 end
@@ -314,11 +315,6 @@ end
 
 @testset "issue in PR #45" begin
     @test length(collect(tokenize("x)"))) == 3
-end
-
-@testset "errors" begin
-    @test tok("#=   #=   =#", 1).kind == K"ErrorEofMultiComment"
-    @test tok("aa **",        3).kind == K"ErrorInvalidOperator"
 end
 
 @testset "xor_eq" begin
@@ -772,7 +768,11 @@ end
     test_error(tok("0b3",1),     K"ErrorInvalidNumericConstant")
     test_error(tok("0op",1),     K"ErrorInvalidNumericConstant")
     test_error(tok("--",1),      K"ErrorInvalidOperator")
-    test_error(tok("1**2",2),    K"ErrorInvalidOperator")
+
+    @test toks("1**2") == ["1"=>K"Integer", "**"=>K"Error**", "2"=>K"Integer"]
+    @test toks("a<---b") == ["a"=>K"Identifier", "<---"=>K"ErrorInvalidOperator", "b"=>K"Identifier"]
+    @test toks("a..+b") == ["a"=>K"Identifier", "..+"=>K"ErrorInvalidOperator", "b"=>K"Identifier"]
+    @test toks("a..−b") == ["a"=>K"Identifier", "..−"=>K"ErrorInvalidOperator", "b"=>K"Identifier"]
 end
 
 @testset "hat suffix" begin


### PR DESCRIPTION
Here we emit invalid token errors during the token validation pass. This ensures any invalid token after parsing is guarenteed to have one single error emitted for it, independent from how it's handled by the parser. Add the special K"Error**" kind to allow us to emit a specific error for the `**` operator.

Ensure we reject all the invalid operators which are rejected by the reference parser including the following which were missing:
* `..+` and similar
* `<---`

Also add an extra rule for parsing invalid binary operators (at some arbitrarily-chosen precedence) to improve the recovered parse tree.

Fix #112 
Part of #172