### PR TITLE
Fix deindentation with triple strings like `"""\n$x a"""`

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3181,6 +3181,11 @@ function parse_string(ps::ParseState, raw::Bool)
         k = kind(t)
         if k == K"$"
             @assert !raw  # The lexer detects raw strings separately
+            if prev_chunk_newline
+                # """\n$x\n a"""  ==>  (string-s x "\n" " a")
+                indent_ref_i = first_byte(t)
+                indent_ref_len = 0
+            end
             bump(ps, TRIVIA_FLAG)
             k = peek(ps)
             if k == K"("

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -816,6 +816,7 @@ tests = [
         ((v=v"1.8",), "[\n  ;; \n ]")  =>  "(ncat-2)"
         ((v=v"1.7",), "[;;]")  =>  "(ncat-2 (error))"
         # parse_string
+        "\"\"\"\n\$x\n a\"\"\"" => "(string-s x \"\\n\" \" a\")"
         "\"a \$(x + y) b\""  =>  "(string \"a \" (call-i x + y) \" b\")"
         "\"hi\$(\"ho\")\""   =>  "(string \"hi\" (string \"ho\"))"
         "\"a \$foo b\""  =>  "(string \"a \" foo \" b\")"


### PR DESCRIPTION
When an interpolation occurs at the beginning of a line without any preceding whitespace this counts as zeroing out the common prefix of indentation.