### PR TITLE
Fixes for General registry testing

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -16,10 +16,12 @@ const _kind_names =
         # Tokenization errors
         "ErrorEofMultiComment"
         "ErrorInvalidNumericConstant"
+        "ErrorAmbiguousNumericConstant"
         "ErrorInvalidInterpolationTerminator"
         "ErrorNumericOverflow"
         "ErrorInvalidEscapeSequence"
         "ErrorOverLongCharacter"
+        "ErrorUnknownCharacter"
         # Generic error
         "error"
     "END_ERRORS"
@@ -1014,10 +1016,12 @@ const _nonunique_kind_names = Set([
 
     K"ErrorEofMultiComment"
     K"ErrorInvalidNumericConstant"
+    K"ErrorAmbiguousNumericConstant"
     K"ErrorInvalidInterpolationTerminator"
     K"ErrorNumericOverflow"
     K"ErrorInvalidEscapeSequence"
     K"ErrorOverLongCharacter"
+    K"ErrorUnknownCharacter"
     K"ErrorInvalidOperator"
 
     K"Integer"
@@ -1053,6 +1057,20 @@ function untokenize(k::Kind; unique=true)
     end
 end
 
+# Error kind => description
+_token_error_descriptions = Dict{Kind, String}(
+    K"ErrorEofMultiComment" => "unterminated multi-line comment #= ... =#",
+    K"ErrorInvalidNumericConstant" => "invalid numeric constant",
+    K"ErrorAmbiguousNumericConstant" => "ambiguous `.` syntax; add whitespace to clarify (eg `1.+2` might be `1.0+2` or `1 .+ 2`)",
+    K"ErrorInvalidInterpolationTerminator" => "interpolated variable ends with invalid character; use `\$(...)` instead",
+    K"ErrorNumericOverflow"=>"overflow in numeric literal",
+    K"ErrorInvalidEscapeSequence"=>"invalid string escape sequence",
+    K"ErrorOverLongCharacter"=>"character literal contains multiple characters",
+    K"ErrorUnknownCharacter"=>"unknown unicode character",
+    K"ErrorInvalidOperator" => "invalid operator",
+    K"Error**" => "use `x^y` instead of `x**y` for exponentiation, and `x...` instead of `**x` for splatting",
+    K"error" => "unknown error token",
+)
 
 #-------------------------------------------------------------------------------
 # Predicates

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -913,7 +913,7 @@ function validate_tokens(stream::ParseStream)
         elseif is_error(k) && k != K"error"
             # Emit messages for non-generic token errors
             emit_diagnostic(stream, fbyte, lbyte,
-                            error=Tokenize.TOKEN_ERROR_DESCRIPTION[k])
+                            error=_token_error_descriptions[k])
         end
         if error_kind != K"None"
             toks[i] = SyntaxToken(SyntaxHead(error_kind, EMPTY_FLAGS),

--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -32,7 +32,7 @@ Logging.with_logger(logger) do
             e2 = open(deserialize, fpath*".Expr")
             @assert Meta.isexpr(e2, :toplevel)
             try
-                e1 = JuliaSyntax.parseall(Expr, code, filename=fpath)
+                e1 = JuliaSyntax.parseall(Expr, code, filename=fpath, ignore_warnings=true)
                 if !exprs_roughly_equal(e2, e1)
                     mismatch_count += 1
                     @error("Parsers succeed but disagree",

--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -12,68 +12,73 @@ logger = Logging.ConsoleLogger(logio)
 
 pkgspath = joinpath(@__DIR__, "pkgs")
 
+exception_count = 0
+mismatch_count = 0
+file_count = 0
+t0 = time()
 exceptions = []
+
 Logging.with_logger(logger) do
-    t = time()
-    i = 0
-    iob = IOBuffer()
-    exception_count = 0
-    mismatch_count = 0
+    global exception_count, mismatch_count, file_count, t0
     for (r, _, files) in walkdir(pkgspath)
         for f in files
             endswith(f, ".jl") || continue
             fpath = joinpath(r, f)
-            if isfile(fpath)
-                code = read(fpath, String)
-                expr_cache = fpath*".Expr"
-                #e2 = JuliaSyntax.fl_parseall(code)
-                e2 = open(deserialize, fpath*".Expr")
-                @assert Meta.isexpr(e2, :toplevel)
-                try
-                    e1 = JuliaSyntax.parseall(Expr, code, filename=fpath)
-                    if !exprs_roughly_equal(e2, e1)
-                        mismatch_count += 1
-                        @error("Parsers succeed but disagree",
-                               fpath,
-                               diff=Text(sprint(show_expr_text_diff, show, e1, e2)),
-                               )
-                    end
-                catch err
-                    err isa InterruptException && rethrow()
-                    ex = (err, catch_backtrace())
-                    push!(exceptions, ex)
-                    ref_parse = "success"
-                    if length(e2.args) >= 1 && Meta.isexpr(last(e2.args), (:error, :incomplete))
-                        ref_parse = "fail"
-                        if err isa JuliaSyntax.ParseError
-                            # Both parsers agree that there's an error, and
-                            # JuliaSyntax didn't have an internal error.
-                            continue
-                        end
-                    end
+            isfile(fpath) || continue
 
-                    exception_count += 1
-                    parse_to_syntax = "success"
-                    try
-                        JuliaSyntax.parseall(JuliaSyntax.SyntaxNode, code)
-                    catch err2
-                        parse_to_syntax = "fail"
-                    end
-                    @error "Parse failed" fpath exception=ex parse_to_syntax
+            code = read(fpath, String)
+            expr_cache = fpath*".Expr"
+            #e2 = JuliaSyntax.fl_parseall(code)
+            e2 = open(deserialize, fpath*".Expr")
+            @assert Meta.isexpr(e2, :toplevel)
+            try
+                e1 = JuliaSyntax.parseall(Expr, code, filename=fpath)
+                if !exprs_roughly_equal(e2, e1)
+                    mismatch_count += 1
+                    @error("Parsers succeed but disagree",
+                           fpath,
+                           diff=Text(sprint(show_expr_text_diff, show, e1, e2)),
+                           )
                 end
+            catch err
+                err isa InterruptException && rethrow()
+                ex = (err, catch_backtrace())
+                push!(exceptions, ex)
+                ref_parse = "success"
+                if length(e2.args) >= 1 && Meta.isexpr(last(e2.args), (:error, :incomplete))
+                    ref_parse = "fail"
+                    if err isa JuliaSyntax.ParseError
+                        # Both parsers agree that there's an error, and
+                        # JuliaSyntax didn't have an internal error.
+                        continue
+                    end
+                end
+
+                exception_count += 1
+                parse_to_syntax = "success"
+                try
+                    JuliaSyntax.parseall(JuliaSyntax.SyntaxNode, code)
+                catch err2
+                    parse_to_syntax = "fail"
+                end
+                @error "Parse failed" fpath exception=ex parse_to_syntax
             end
-            i += 1
-            if i % 100 == 0
-                runtime = time() - t
-                avg = round(runtime/i*1000, digits = 2)
-                print(iob, "\e[2J\e[0;0H")
-                println(iob, "$i files parsed")
-                println(iob, "> $(exception_count) failures compared to reference parser")
-                println(iob, "> $(mismatch_count) Expr mismatches")
-                println(iob, "> $(avg)ms per file, $(round(Int, runtime))s in total")
-                println(stderr, String(take!(iob)))
+
+            file_count += 1
+            if file_count % 100 == 0
+                t_avg = round((time() - t0)/file_count*1000, digits = 2)
+                print(stderr, "\r$file_count files parsed, $t_avg ms per file")
             end
         end
     end
 end
 close(logio)
+
+t_avg = round((time() - t0)/file_count*1000, digits = 2)
+
+println()
+@info """
+    Finished parsing $file_count files.
+        $(exception_count) failures compared to reference parser
+        $(mismatch_count) Expr mismatches
+        $(t_avg)ms per file"""


### PR DESCRIPTION
* Improve logging for general registry testing and ignore parser warnings rather than erroring
* Use specific kinds for token errors, not `K"error"`. This fixes a few cases across the General registry where errors should have been reported but were not.
