### PR TITLE
Support for running JuliaSyntax on Julia 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.0'
+          - '1.1'
+          - '1.2'
+          - '1.3'
+          - '1.4'
+          - '1.5'
           - '1.6'
+          - '1.7'
           - '1'
           - 'nightly'
         os:
@@ -22,6 +29,26 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          # Test all OS's on
+          # - 1.0
+          # - 1.6
+          # - 1
+          # - nightly
+          # but remove some configurations from the build matrix to reduce CI time.
+          # See https://github.com/marketplace/actions/setup-julia-environment
+          - {os: 'macOS-latest', version: '1.1'}
+          - {os: 'macOS-latest', version: '1.2'}
+          - {os: 'macOS-latest', version: '1.3'}
+          - {os: 'macOS-latest', version: '1.4'}
+          - {os: 'macOS-latest', version: '1.5'}
+          - {os: 'macOS-latest', version: '1.7'}
+          - {os: 'windows-latest', version: '1.1'}
+          - {os: 'windows-latest', version: '1.2'}
+          - {os: 'windows-latest', version: '1.3'}
+          - {os: 'windows-latest', version: '1.4'}
+          - {os: 'windows-latest', version: '1.5'}
+          - {os: 'windows-latest', version: '1.7'}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
 version = "0.2.0"
 
 [compat]
-julia = "1.6"
+julia = "1.0"
 
 [deps]
 

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -45,9 +45,9 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
                       Symbol("@big_str")
             return Expr(:macrocall, GlobalRef(Core, macname), nothing, str)
         elseif kind(node) == K"core_@doc"
-            return GlobalRef(Core, :var"@doc")
+            return GlobalRef(Core, Symbol("@doc"))
         elseif kind(node) == K"core_@cmd"
-            return GlobalRef(Core, :var"@cmd")
+            return GlobalRef(Core, Symbol("@cmd"))
         elseif kind(node) == K"MacroName" && val === Symbol("@.")
             return Symbol("@__dot__")
         else

--- a/src/source_files.jl
+++ b/src/source_files.jl
@@ -65,7 +65,8 @@ function source_line_range(source::SourceFile, byte_index;
 end
 
 function source_location(::Type{LineNumberNode}, source::SourceFile, byte_index)
-    LineNumberNode(source_line(source, byte_index), source.filename)
+    LineNumberNode(source_line(source, byte_index),
+                   isnothing(source.filename) ? nothing : Symbol(source.filename))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", source::SourceFile)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,21 @@
+# Compatibility hacks for older Julia versions
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
+end
+if VERSION < v"1.4"
+    function only(x::AbstractVector)
+        if length(x) != 1
+            error("Collection must contain exactly 1 element")
+        end
+        return x[1]
+    end
+end
+if VERSION < v"1.5"
+    import Base.peek
+end
+
+#--------------------------------------------------
+#
 # Internal error, used as assertion failure for cases we expect can't happen.
 @noinline function internal_error(strs...)
     error("Internal error: ", strs...)

--- a/src/value_parsing.jl
+++ b/src/value_parsing.jl
@@ -122,7 +122,7 @@ end
 @inline function _unsafe_parse_float(::Type{Float64}, ptr, strsize)
     Libc.errno(0)
     endptr = Ref{Ptr{UInt8}}(C_NULL)
-    x = @ccall jl_strtod_c(ptr::Ptr{UInt8}, endptr::Ptr{Ptr{UInt8}})::Cdouble
+    x = ccall(:jl_strtod_c, Cdouble, (Ptr{UInt8}, Ptr{Ptr{UInt8}}), ptr, endptr)
     @check endptr[] == ptr + strsize
     status = :ok
     if Libc.errno() == Libc.ERANGE
@@ -155,13 +155,13 @@ end
         # strtof seems buggy on windows and doesn't set ERANGE correctly on
         # overflow. See also
         # https://github.com/JuliaLang/julia/issues/46544
-        x = Float32(@ccall jl_strtod_c(ptr::Ptr{UInt8}, endptr::Ptr{Ptr{UInt8}})::Cdouble)
+        x = Float32(ccall(:jl_strtod_c, Cdouble, (Ptr{UInt8}, Ptr{Ptr{UInt8}}), ptr, endptr))
         if isinf(x)
             status = :overflow
             # Underflow not detected, but that will only be a warning elsewhere.
         end
     else
-        x = @ccall jl_strtof_c(ptr::Ptr{UInt8}, endptr::Ptr{Ptr{UInt8}})::Cfloat
+        x = ccall(:jl_strtof_c, Cfloat, (Ptr{UInt8}, Ptr{Ptr{UInt8}}), ptr, endptr)
     end
     @check endptr[] == ptr + strsize
     if Libc.errno() == Libc.ERANGE

--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -1,9 +1,11 @@
 # Full-scale parsing tests of JuliaSyntax itself, Julia Base, etc.
 
+juliasyntax_dir = joinpath(@__DIR__, "..")
 @testset "Parse JuliaSyntax" begin
-    pkgdir = joinpath(@__DIR__, "..")
-    test_parse_all_in_path(joinpath(pkgdir, "src"))
-    test_parse_all_in_path(joinpath(pkgdir, "test"))
+    test_parse_all_in_path(joinpath(juliasyntax_dir, "src"))
+end
+@testset "Parse JuliaSyntax tests" begin
+    test_parse_all_in_path(joinpath(juliasyntax_dir, "test"))
 end
 
 base_path = let

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -82,14 +82,13 @@
     end
 
     @testset "error/warning handling" begin
-        # ignore_warnings
-        parse_sexpr(s;kws...) = sprint(show, MIME("text/x.sexpression"), parse(SyntaxNode, s; kws...))
-        @test_throws JuliaSyntax.ParseError parse_sexpr("try finally catch ex end")
-        @test parse_sexpr("try finally catch ex end", ignore_warnings=true) ==
+        parseshow(s;kws...) = sprint(show, MIME("text/x.sexpression"), parse(SyntaxNode, s; kws...))
+        @test_throws JuliaSyntax.ParseError parseshow("try finally catch ex end")
+        @test parseshow("try finally catch ex end", ignore_warnings=true) ==
             "(try_finally_catch (block) false false false (block) ex (block))"
         # ignore_errors
-        @test_throws JuliaSyntax.ParseError parse_sexpr("[a; b, c]")
-        @test_throws JuliaSyntax.ParseError parse_sexpr("[a; b, c]", ignore_warnings=true)
-        @test parse_sexpr("[a; b, c]", ignore_errors=true) == "(vcat a b (error-t) c)"
+        @test_throws JuliaSyntax.ParseError parseshow("[a; b, c]")
+        @test_throws JuliaSyntax.ParseError parseshow("[a; b, c]", ignore_warnings=true)
+        @test parseshow("[a; b, c]", ignore_errors=true) == "(vcat a b (error-t) c)"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,13 @@ include("expr.jl")
 @testset "Parsing literals from strings" begin
     include("value_parsing.jl")
 end
-include("hooks.jl")
-include("parse_packages.jl")
 include("source_files.jl")
+
+if VERSION >= v"1.6"
+    # Tests restricted to 1.6+ due to
+    # * Core._parse hook doesn't exist on v1.5 and lower
+    # * Reference parser bugs which would need workarounds for package parse comparisons
+    include("hooks.jl")
+    include("parse_packages.jl")
+end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,28 @@ using JuliaSyntax: GreenNode, SyntaxNode,
     flags, EMPTY_FLAGS, TRIVIA_FLAG, INFIX_FLAG,
     children, child, setchild!, SyntaxHead
 
+include("test_utils.jl")
+# Tests for the test_utils go here to allow the utils to be included on their
+# own without invoking the tests.
+@testset "Test tools" begin
+    @test exprs_roughly_equal(Expr(:global, :x, :y),
+                              Expr(:global, Expr(:tuple, :x, :y)))
+    @test exprs_roughly_equal(Expr(:local, :x, :y),
+                              Expr(:local, Expr(:tuple, :x, :y)))
+    @test exprs_roughly_equal(1.5,
+                              Expr(:call, :*, 1.5, :f))
+    @test exprs_roughly_equal(1.5,
+                              Expr(:call, :*, 1.5, :f0))
+    @test exprs_roughly_equal(Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:kw, :a, 1)),
+                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))),
+                              Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:(=), :a, 1)),
+                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))))
+end
+
 @testset "Tokenize" begin
     include("tokenize.jl")
 end
 
-include("test_utils.jl")
 include("parse_stream.jl")
 include("parser.jl")
 include("diagnostics.jl")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -351,6 +351,7 @@ function show_green_tree(code; version::VersionNumber=v"1.6")
     sprint(show, MIME"text/plain"(), t, code)
 end
 
+
 #-------------------------------------------------------------------------------
 # Parse s-expressions
 function parse_sexpr(code)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -389,17 +389,3 @@ function parse_sexpr(code)
 end
 
 
-@testset "Test tools" begin
-    @test exprs_roughly_equal(Expr(:global, :x, :y),
-                              Expr(:global, Expr(:tuple, :x, :y)))
-    @test exprs_roughly_equal(Expr(:local, :x, :y),
-                              Expr(:local, Expr(:tuple, :x, :y)))
-    @test exprs_roughly_equal(1.5,
-                              Expr(:call, :*, 1.5, :f))
-    @test exprs_roughly_equal(1.5,
-                              Expr(:call, :*, 1.5, :f0))
-    @test exprs_roughly_equal(Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:kw, :a, 1)),
-                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))),
-                              Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:(=), :a, 1)),
-                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))))
-end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -28,6 +28,11 @@ using .JuliaSyntax:
     fl_parseall,
     fl_parse
 
+if VERSION < v"1.6"
+    # Compat stuff which might not be in Base for older versions
+    using JuliaSyntax: isnothing, only, peek
+end
+
 function remove_macro_linenums!(ex)
     if Meta.isexpr(ex, :macrocall)
         ex.args[2] = nothing
@@ -69,7 +74,7 @@ function parse_diff(text, showfunc=dump)
 end
 
 function kw_to_eq(ex)
-    return Meta.isexpr(:kw, ex) ? Expr(:(=), ex.args...) : ex
+    return Meta.isexpr(ex, :kw) ? Expr(:(=), ex.args...) : ex
 end
 
 function triple_string_roughly_equal(str, fl_str)

--- a/test/value_parsing.jl
+++ b/test/value_parsing.jl
@@ -66,7 +66,7 @@ octint(s) = parse_uint_literal(s, K"OctInt")
         @test hexint("0x10000000000000000") === UInt128(0x10000000000000000)
         @test hexint("0xffffffffffffffffffffffffffffffff") === UInt128(0xffffffffffffffffffffffffffffffff)
         @test (n = hexint("0x100000000000000000000000000000000");
-               n isa BigInt && n == 0x100000000000000000000000000000000)
+               n isa BigInt && n == big"0x100000000000000000000000000000000")
     end
     @testset "HexInt string length limits for different types" begin
         @test hexint("0x00")  === UInt8(0)
@@ -94,7 +94,7 @@ octint(s) = parse_uint_literal(s, K"OctInt")
         @test binint("0b10000000000000000000000000000000000000000000000000000000000000000") === UInt128(0x10000000000000000)
         @test binint("0b11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111") === UInt128(0xffffffffffffffffffffffffffffffff)
         @test (n = binint("0b100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-               n isa BigInt && n == 0x100000000000000000000000000000000)
+               n isa BigInt && n == big"0x100000000000000000000000000000000")
     end
     @testset "BinInt string length limits for different types" begin
         @test binint("0b00000000")  === UInt8(0)
@@ -122,7 +122,7 @@ octint(s) = parse_uint_literal(s, K"OctInt")
         @test octint("0o2000000000000000000000") === UInt128(0x10000000000000000)
         @test octint("0o3777777777777777777777777777777777777777777") === UInt128(0xffffffffffffffffffffffffffffffff)
         @test (n = octint("0o4000000000000000000000000000000000000000000");
-               n isa BigInt && n == 0x100000000000000000000000000000000)
+               n isa BigInt && n == big"0x100000000000000000000000000000000")
     end
     @testset "OctInt string length limits for different types" begin
         @test octint("0o000")  === UInt8(0)

--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -33,7 +33,7 @@ Logging.with_logger(logger) do
             @assert Meta.isexpr(e2, :toplevel)
             try
                 e1 = JuliaSyntax.parseall(Expr, code, filename=fpath, ignore_warnings=true)
-                if !exprs_roughly_equal(e2, e1)
+                if !exprs_roughly_equal(e2, e1, strict_triple_strs=false)
                     mismatch_count += 1
                     @error("Parsers succeed but disagree",
                            fpath,


### PR DESCRIPTION
Mostly just compat changes here, adding a bunch of Base utility functions we use which don't exist in earlier Julia versions.

There's still a few failures in the extended tests, probably due to differences in line number node placement and the like in the reference parser.

Fix #180