### PR TITLE
Make things compabitle with Julia 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.0'
           - '1.6'
           - '1'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Chris Foster <chris42f@gmail.com> and contributors"]
 version = "0.2.0"
 
 [compat]
-julia = "1.6"
+julia = "1.0"
 
 [deps]
 

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -45,9 +45,9 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
                       Symbol("@big_str")
             return Expr(:macrocall, GlobalRef(Core, macname), nothing, str)
         elseif kind(node) == K"core_@doc"
-            return GlobalRef(Core, :var"@doc")
+            return GlobalRef(Core, Symbol("@doc"))
         elseif kind(node) == K"core_@cmd"
-            return GlobalRef(Core, :var"@cmd")
+            return GlobalRef(Core, Symbol("@cmd"))
         elseif kind(node) == K"MacroName" && val === Symbol("@.")
             return Symbol("@__dot__")
         else

--- a/src/value_parsing.jl
+++ b/src/value_parsing.jl
@@ -122,7 +122,7 @@ end
 @inline function _unsafe_parse_float(::Type{Float64}, ptr, strsize)
     Libc.errno(0)
     endptr = Ref{Ptr{UInt8}}(C_NULL)
-    x = @ccall jl_strtod_c(ptr::Ptr{UInt8}, endptr::Ptr{Ptr{UInt8}})::Cdouble
+    x = ccall(:jl_strtod_c, Cdouble, (Ptr{UInt8}, Ptr{Ptr{UInt8}}), ptr, endptr)
     @check endptr[] == ptr + strsize
     status = :ok
     if Libc.errno() == Libc.ERANGE
@@ -155,13 +155,13 @@ end
         # strtof seems buggy on windows and doesn't set ERANGE correctly on
         # overflow. See also
         # https://github.com/JuliaLang/julia/issues/46544
-        x = Float32(@ccall jl_strtod_c(ptr::Ptr{UInt8}, endptr::Ptr{Ptr{UInt8}})::Cdouble)
+        x = Float32(ccall(:jl_strtod_c, Cdouble, (Ptr{UInt8}, Ptr{Ptr{UInt8}}), ptr, endptr))
         if isinf(x)
             status = :overflow
             # Underflow not detected, but that will only be a warning elsewhere.
         end
     else
-        x = @ccall jl_strtof_c(ptr::Ptr{UInt8}, endptr::Ptr{Ptr{UInt8}})::Cfloat
+        x = ccall(:jl_strtof_c, Cfloat, (Ptr{UInt8}, Ptr{Ptr{UInt8}}), ptr, endptr)
     end
     @check endptr[] == ptr + strsize
     if Libc.errno() == Libc.ERANGE


### PR DESCRIPTION
Fixes #180.

Right now I'm stuck with a bug in hooks.jl, namely `Core.Compiler.fl_parse` does not exist in Julia 1.0. @c42f, any idea how we can get around that? The goal here is to make simply make it possible to run JuliaSyntax in the LanguageServer, so no need for any of the stuff that replaces things in Julia itself.