### PR TITLE
Allow different parsings of `(a; b,)` to compare equal

### DIFF
--- a/test/expr.jl
+++ b/test/expr.jl
@@ -161,8 +161,6 @@
         @test parse(Expr, "'a'") == 'a'
         @test parse(Expr, "'α'") == 'α'
         @test parse(Expr, "'\\xce\\xb1'") == 'α'
-        # FIXME
-        # @test_throws ParseError parse(Expr, "'abcde'")
     end
 
     @testset "do block conversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,21 +8,38 @@ using JuliaSyntax: GreenNode, SyntaxNode,
     children, child, setchild!, SyntaxHead
 
 include("test_utils.jl")
+
 # Tests for the test_utils go here to allow the utils to be included on their
 # own without invoking the tests.
-@testset "Test tools" begin
+@testset "Reference parser bugs" begin
+    # `global (x,y)`
     @test exprs_roughly_equal(Expr(:global, :x, :y),
                               Expr(:global, Expr(:tuple, :x, :y)))
     @test exprs_roughly_equal(Expr(:local, :x, :y),
                               Expr(:local, Expr(:tuple, :x, :y)))
+    # `0x1.8p0f`
     @test exprs_roughly_equal(1.5,
                               Expr(:call, :*, 1.5, :f))
     @test exprs_roughly_equal(1.5,
                               Expr(:call, :*, 1.5, :f0))
+    # `@f(a=1) do \n end`
     @test exprs_roughly_equal(Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:kw, :a, 1)),
                                    Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))),
                               Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:(=), :a, 1)),
                                    Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))))
+    # `"""\n  a\n \n  b"""`
+    @test exprs_roughly_equal("a\n \nb", " a\n\n b")
+    @test !exprs_roughly_equal("a\n x\nb", " a\n x\n b")
+    @test exprs_roughly_equal("a\n x\nb", "a\n x\nb")
+    # `(a; b,)`
+    @test exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
+                              Expr(:tuple, Expr(:parameters, :b), :a))
+    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
+                               Expr(:tuple, Expr(:parameters, :c), :a))
+    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
+                               Expr(:tuple, Expr(:parameters, :b), :c))
+    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b, :c),
+                               Expr(:tuple, Expr(:parameters, :b), :a))
 end
 
 @testset "Tokenize" begin


### PR DESCRIPTION
The reference parser sees `(a; b,)` as a block, but the trailing comma implies this should be a frakentuple. Allow this unusual syntax as a minor bug in the reference parser.

Part of #134 