### PR TITLE
Allow SyntaxNode `node[end]` to get the last child

### DIFF
--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -254,6 +254,10 @@ end
 function Base.getindex(node::Union{SyntaxNode,GreenNode}, path::Int...)
     child(node, path...)
 end
+function Base.lastindex(node::Union{SyntaxNode,GreenNode})
+    length(children(node))
+end
+
 function Base.setindex!(node::SyntaxNode, x::SyntaxNode, path::Int...)
     setchild!(node, path, x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
 
 include("parse_stream.jl")
 include("parser.jl")
+include("syntax_tree.jl")
 include("diagnostics.jl")
 include("parser_api.jl")
 include("expr.jl")

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -1,0 +1,18 @@
+@testset "SyntaxNode" begin
+    # Child access
+    t = parse(SyntaxNode, "a*b + c")
+
+    @test sourcetext(child(t, 1))    == "a*b"
+    @test sourcetext(child(t, 1, 1)) == "a"
+    @test sourcetext(child(t, 1, 2)) == "*"
+    @test sourcetext(child(t, 1, 3)) == "b"
+    @test sourcetext(child(t, 2))    == "+"
+    @test sourcetext(child(t, 3))    == "c"
+
+    # Child indexing
+    @test t[1]    === child(t, 1)
+    @test t[1, 1] === child(t, 1, 1)
+    @test t[end]  === child(t, 3)
+    # Unfortunately, can't make t[1, end] work
+    # as `lastindex(t, 2)` isn't well defined
+end


### PR DESCRIPTION
CC @timholy 

Tim, if there's other API improvements we should have to make the use in https://github.com/JuliaDebug/Cthulhu.jl/pull/345 let's do those too.