### PR TITLE
Split SyntaxNode into TreeNode & SyntaxData

### DIFF
--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -9,6 +9,24 @@ mutable struct TreeNode{NodeData}   # ? prevent others from using this with Node
     data::Union{Nothing,NodeData}
 end
 
+# Implement "pass-through" semantics for field access: access fields of `data`
+# as if they were part of `TreeNode`
+function Base.getproperty(node::TreeNode, name::Symbol)
+    name === :parent && return getfield(node, :parent)
+    name === :children && return getfield(node, :children)
+    d = getfield(node, :data)
+    name === :data && return d
+    return getproperty(d, name)
+end
+
+function Base.setproperty!(node::TreeNode, name::Symbol, x)
+    name === :parent && return setfield!(node, :parent, x)
+    name === :children && return setfield!(node, :children, x)
+    name === :data && return setfield!(node, :data, x)
+    d = getfield(node, :data)
+    return setfield!(d, name, x)
+end
+
 const AbstractSyntaxNode = TreeNode{<:AbstractSyntaxData}
 
 struct SyntaxData <: AbstractSyntaxData
@@ -128,14 +146,6 @@ function SyntaxNode(source::SourceFile, raw::GreenNode{SyntaxHead}, position::In
         end
         return node
     end
-end
-
-function Base.getproperty(node::TreeNode, name::Symbol)
-    name === :parent && return getfield(node, :parent)
-    name === :children && return getfield(node, :children)
-    d = getfield(node, :data)
-    name === :data && return d
-    return getproperty(d, name)
 end
 
 haschildren(node::TreeNode) = node.children !== nothing

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -16,12 +16,6 @@ end
 
 const SyntaxNode = TreeNode{SyntaxData}
 
-"""
-Design options:
-* rust-analyzer treats their version of an untyped syntax node as a cursor into
-  the green tree. They deallocate aggressively.
-"""
-
 # Value of an error node with no children
 struct ErrorVal
 end

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -30,7 +30,9 @@
     # Pass-through field access
     node = child(t, 1, 1)
     @test node.val === :a
-    @test_throws ErrorException("setfield!: immutable struct of type SyntaxData cannot be changed") node.val = :q
+    # The specific error text has evolved over Julia versions. Check that it involves `SyntaxData` and immutability
+    e = try node.val = :q catch e e end
+    @test occursin("immutable", e.msg) && occursin("SyntaxData", e.msg)
 
     node = parse(SyntaxNode, "f()")
     push!(node, parse(SyntaxNode, "x"))

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -27,6 +27,11 @@
     @test sprint(JuliaSyntax.highlight, tt, t, 1, 3) == "a*\e[48;2;40;40;70mb\e[0;0m + c"
     @test sprint(JuliaSyntax.highlight, tt, t.raw, 5) == "a*b + \e[48;2;40;40;70mc\e[0;0m"
 
+    # Pass-through field access
+    node = child(t, 1, 1)
+    @test node.val === :a
+    @test_throws ErrorException("setfield!: immutable struct of type SyntaxData cannot be changed") node.val = :q
+
     node = parse(SyntaxNode, "f()")
     push!(node, parse(SyntaxNode, "x"))
     @test length(children(node)) == 2


### PR DESCRIPTION
Closes #192

Pleasantly straightforward. Note that this object is slightly bigger since `val` has basically become two fields now, one for children and one for the actual value. I hope that's a tolerable increase.

I haven't timed anything to see if there are any regressions. (If constprop works, I think there won't be any.) Is there a task I should use?
