### PR TITLE
Fix various numeric literal token errors

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -16,7 +16,9 @@ const _kind_names =
         # Tokenization errors
         "ErrorEofMultiComment"
         "ErrorInvalidNumericConstant"
+        "ErrorHexFloatMustContainP"
         "ErrorAmbiguousNumericConstant"
+        "ErrorAmbiguousNumericDotMultiply"
         "ErrorInvalidInterpolationTerminator"
         "ErrorNumericOverflow"
         "ErrorInvalidEscapeSequence"
@@ -1016,7 +1018,9 @@ const _nonunique_kind_names = Set([
 
     K"ErrorEofMultiComment"
     K"ErrorInvalidNumericConstant"
+    K"ErrorHexFloatMustContainP"
     K"ErrorAmbiguousNumericConstant"
+    K"ErrorAmbiguousNumericDotMultiply"
     K"ErrorInvalidInterpolationTerminator"
     K"ErrorNumericOverflow"
     K"ErrorInvalidEscapeSequence"
@@ -1061,7 +1065,9 @@ end
 _token_error_descriptions = Dict{Kind, String}(
     K"ErrorEofMultiComment" => "unterminated multi-line comment #= ... =#",
     K"ErrorInvalidNumericConstant" => "invalid numeric constant",
+    K"ErrorHexFloatMustContainP" => "hex float literal must contain `p` or `P`",
     K"ErrorAmbiguousNumericConstant" => "ambiguous `.` syntax; add whitespace to clarify (eg `1.+2` might be `1.0+2` or `1 .+ 2`)",
+    K"ErrorAmbiguousNumericDotMultiply" => "numeric constant cannot be implicitly multiplied because it ends with `.`",
     K"ErrorInvalidInterpolationTerminator" => "interpolated variable ends with invalid character; use `\$(...)` instead",
     K"ErrorNumericOverflow"=>"overflow in numeric literal",
     K"ErrorInvalidEscapeSequence"=>"invalid string escape sequence",

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1103,9 +1103,6 @@ function is_juxtapose(ps, prev_k, t)
          !(is_block_form(prev_k)         ||
            is_syntactic_unary_op(prev_k) ||
            is_initial_reserved_word(ps, prev_k) )))  &&
-    # https://github.com/JuliaLang/julia/issues/16356
-    # 0xenomorph  ==>  0x0e
-    !(prev_k in KSet"BinInt HexInt OctInt" && (k == K"Identifier" || is_keyword(k))) &&
     (!is_operator(k) || is_radical_op(k))            &&
     !is_closing_token(ps, k)                         &&
     !is_initial_reserved_word(ps, k)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -121,3 +121,7 @@ function _fl_parse_string(text::AbstractString, filename::AbstractString,
     ex, offset+1
 end
 
+# Convenience functions to mirror `JuliaSyntax.parse(Expr, ...)` in simple cases.
+fl_parse(::Type{Expr}, args...; kws...) = fl_parse(args...; kws...)
+fl_parseall(::Type{Expr}, args...; kws...) = fl_parseall(args...; kws...)
+

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -193,7 +193,6 @@ tests = [
         "sqrt(2)2"  =>  "(call sqrt 2)"
         "x' y"      =>  "(call-post x ')"
         "x 'y"      =>  "x"
-        "0xenomorph" => "0x0e"
     ],
     JuliaSyntax.parse_unary => [
         ":T"       => "(quote T)"
@@ -950,17 +949,6 @@ broken_tests = [
         "@!x"   => "(macrocall @! x)"
         "@..x"  => "(macrocall @.. x)"
         "@.x"   => "(macrocall @__dot__ x)"
-        # Invalid numeric literals, not juxtaposition
-        "0b12" => "(error \"0b12\")"
-        "0xex" => "(error \"0xex\")"
-        # Bad character literals
-        "'\\xff'"  => "(error '\\xff')"
-        "'\\x80'"  => "(error '\\x80')"
-        "'ab'"     => "(error 'ab')"
-    ]
-    JuliaSyntax.parse_juxtapose => [
-        # Want: "numeric constant \"10.\" cannot be implicitly multiplied because it ends with \".\""
-        "10.x" => "(error (call * 10.0 x))"
     ]
 ]
 


### PR DESCRIPTION
A fairly big refactor of numeric literal tokenization error cases and a couple of other tokenizer errors ported from the flisp code.

* For hexfloat, emit a more specific errors when the `p` suffix is missing.
* For octal, hex and binary, add errors for trailing invalid digits or identifier characters like `0b123` and `0xenomorph`
* Emit an error for ambiguous numeric constants with dot suffix vs juxtuposition like `1.(`
* Emit an error for underscore directly after dot as in `1._`
* Emit an error for hexfloat without digits `0x.p0`
* Add an invalid operator error for `<---` to follow compatibility with the reference parser.

Refactor and regroup all the numeric tokenization tests which were confusingly grouped.

Fix #57 #172