### PR TITLE
Fix `try catch else` Expr conversion

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -213,7 +213,7 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
         end
         # At this point args is
         # [try_block catch_var catch_block]
-        if finally_ !== false
+        if finally_ !== false || else_ !== false
             push!(args, finally_)
         end
         if else_ !== false

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -261,4 +261,38 @@
         @test parse(Expr, "@.") == Expr(:macrocall, Symbol("@__dot__"), LineNumberNode(1))
         @test parse(Expr, "using A: @.") == Expr(:using, Expr(Symbol(":"), Expr(:., :A), Expr(:., Symbol("@__dot__"))))
     end
+
+    @testset "try" begin
+        @test parse(Expr, "try x catch e; y end") ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 :e,
+                 Expr(:block, LineNumberNode(1), :y))
+        @test parse(Expr, "try x finally y end") ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 false,
+                 false,
+                 Expr(:block, LineNumberNode(1), :y))
+        @test parse(Expr, "try x catch e; y finally z end") ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 :e,
+                 Expr(:block, LineNumberNode(1), :y),
+                 Expr(:block, LineNumberNode(1), :z))
+        @test parse(Expr, "try x catch e; y else z end", version=v"1.8") ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 :e,
+                 Expr(:block, LineNumberNode(1), :y),
+                 false,
+                 Expr(:block, LineNumberNode(1), :z))
+        @test parse(Expr, "try x catch e; y else z finally w end", version=v"1.8") ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 :e,
+                 Expr(:block, LineNumberNode(1), :y),
+                 Expr(:block, LineNumberNode(1), :w),
+                 Expr(:block, LineNumberNode(1), :z))
+    end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -267,7 +267,7 @@ function reduce_test(tree::SyntaxNode)
 end
 
 function reduce_test(text::AbstractString)
-    tree, = parseall(SyntaxNode, text)
+    tree = parseall(SyntaxNode, text)
     reduce_test(tree)
 end
 


### PR DESCRIPTION
This was incorrect when not including a finally clause.