### PR TITLE
Improve test coverge of source_files, syntax_tree

### DIFF
--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -286,10 +286,10 @@ end
 """
 Print the code, highlighting the part covered by `node` at tree `path`.
 """
-function highlight(code::String, node, path::Int...; color=(40,40,70))
+function highlight(io::IO, code::String, node, path::Int...; color=(40,40,70))
     node, p, span = child_position_span(node, path...)
     q = p + span
-    print(stdout, code[1:p-1])
-    _printstyled(stdout, code[p:q-1]; bgcolor=color)
-    print(stdout, code[q:end])
+    print(io, code[1:p-1])
+    _printstyled(io, code[p:q-1]; bgcolor=color)
+    print(io, code[q:end])
 end

--- a/test/source_files.jl
+++ b/test/source_files.jl
@@ -26,7 +26,9 @@
         @test source_location(SourceFile(; filename=path), 1) == (1,1)
         @test source_location(SourceFile(; filename=path, first_line=7), 1) == (7,1)
     end
+end
 
+@testset "SourceFile position indexing" begin
     @test SourceFile("a\nb\n")[1:2] == "a\n"
     @test SourceFile("a\nb\n")[3:end] == "b\n"
     if Base.VERSION >= v"1.4"
@@ -36,4 +38,14 @@
 
     # unicode
     @test SourceFile("αβ")[1:2] == "α"
+    @test SourceFile("αβ")[3] == 'β'
+end
+
+@testset "SourceFile printing and text extraction" begin
+    srcf = SourceFile("module Foo\nend")
+    @test sprint(show, MIME("text/plain"), srcf) == """
+    ## SourceFile ##
+    module Foo
+    end"""
+    @test sourcetext(srcf) == "module Foo\nend"
 end

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -1,6 +1,7 @@
 @testset "SyntaxNode" begin
     # Child access
-    t = parse(SyntaxNode, "a*b + c")
+    tt = "a*b + c"
+    t = parse(SyntaxNode, tt)
 
     @test sourcetext(child(t, 1))    == "a*b"
     @test sourcetext(child(t, 1, 1)) == "a"
@@ -9,10 +10,26 @@
     @test sourcetext(child(t, 2))    == "+"
     @test sourcetext(child(t, 3))    == "c"
 
+    @test JuliaSyntax.first_byte(child(t, 2)) == findfirst(==('+'), tt)
+
     # Child indexing
     @test t[1]    === child(t, 1)
     @test t[1, 1] === child(t, 1, 1)
     @test t[end]  === child(t, 3)
     # Unfortunately, can't make t[1, end] work
     # as `lastindex(t, 2)` isn't well defined
+
+    @test sprint(show, t) == "(call-i (call-i a * b) + c)"
+    str = sprint(show, MIME("text/plain"), t)
+    # These tests are deliberately quite relaxed to avoid being too specific about display style
+    @test occursin("line:col", str)
+    @test occursin("call-i", str)
+    @test sprint(JuliaSyntax.highlight, tt, t, 1, 3) == "a*\e[48;2;40;40;70mb\e[0;0m + c"
+    @test sprint(JuliaSyntax.highlight, tt, t.raw, 5) == "a*b + \e[48;2;40;40;70mc\e[0;0m"
+
+    node = parse(SyntaxNode, "f()")
+    push!(node, parse(SyntaxNode, "x"))
+    @test length(children(node)) == 2
+    node[2] = parse(SyntaxNode, "y")
+    @test sourcetext(child(node, 2)) == "y"
 end


### PR DESCRIPTION
These two files are particularly affected by recent and upcoming
changes (e.g., #193). This adds a bit more coverage as a guard
against breakage.