### PR TITLE
Remove byte_range from default printing of SyntaxNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ the `call` has the infix `-i` flag):
 julia> using JuliaSyntax: JuliaSyntax, SyntaxNode, GreenNode
 
 julia> JuliaSyntax.parse(SyntaxNode, "(x + y)*z", filename="foo.jl")
-line:col│ byte_range  │ tree                                   │ file_name
-   1:1  │     1:9     │[call-i]                                │foo.jl
-   1:2  │     2:6     │  [call-i]
-   1:2  │     2:2     │    x
-   1:4  │     4:4     │    +
-   1:6  │     6:6     │    y
-   1:8  │     8:8     │  *
-   1:9  │     9:9     │  z
+line:col│ tree                                   │ file_name
+   1:1  │[call-i]                                │foo.jl
+   1:2  │  [call-i]
+   1:2  │    x
+   1:4  │    +
+   1:6  │    y
+   1:8  │  *
+   1:9  │  z
 ```
 
 Internally this has a full representation of all syntax trivia (whitespace and

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -40,3 +40,27 @@
     node[2] = parse(SyntaxNode, "y")
     @test sourcetext(child(node, 2)) == "y"
 end
+
+@testset "SyntaxNode pretty printing" begin
+    t = parse(SyntaxNode, "f(a*b,\n  c)", filename="foo.jl")
+    @test sprint(show, MIME("text/plain"), t) == """
+    line:col│ tree                                   │ file_name
+       1:1  │[call]                                  │foo.jl
+       1:1  │  f
+       1:3  │  [call-i]
+       1:3  │    a
+       1:4  │    *
+       1:5  │    b
+       2:3  │  c
+    """
+    @test sprint(io->show(io, MIME("text/plain"), t, show_byte_offsets=true)) == """
+    line:col│ byte_range  │ tree                                   │ file_name
+       1:1  │     1:11    │[call]                                  │foo.jl
+       1:1  │     1:1     │  f
+       1:3  │     3:5     │  [call-i]
+       1:3  │     3:3     │    a
+       1:4  │     4:4     │    *
+       1:5  │     5:5     │    b
+       2:3  │    10:10    │  c
+    """
+end


### PR DESCRIPTION
The byte range is probably most useful for debugging JuliaSyntax than general use. So disable this by default.