### PR TITLE
add a very basic precompile workload

### DIFF
--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -26,5 +26,5 @@ include("expr.jl")
 
 # Hooks to integrate the parser with Base
 include("hooks.jl")
-
+include("precompile.jl")
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,5 @@
 # Just parse some file as a precompile workload
 let filename = joinpath(@__DIR__, "literal_parsing.jl")
     text = read(filename, String)
-    stream = JuliaSyntax.ParseStream(text)
-    JuliaSyntax.parse!(stream)
+    parseall(Expr, text)
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,5 @@
+# Just parse some file as a precompile workload
+filename = joinpath(@__DIR__, "literal_parsing.jl")
+text = read(filename, String)
+stream = JuliaSyntax.ParseStream(text)
+JuliaSyntax.parse!(stream)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,6 @@
 # Just parse some file as a precompile workload
-filename = joinpath(@__DIR__, "literal_parsing.jl")
-text = read(filename, String)
-stream = JuliaSyntax.ParseStream(text)
-JuliaSyntax.parse!(stream)
+let filename = joinpath(@__DIR__, "literal_parsing.jl")
+    text = read(filename, String)
+    stream = JuliaSyntax.ParseStream(text)
+    JuliaSyntax.parse!(stream)
+end


### PR DESCRIPTION
I want to use this package in OhMyREPL but the current latency is too big. This PR makes it as good as Tokenize.jl

Before:

```
julia> @time @eval collect(JuliaSyntax.Tokenize.Lexer("1+1 == 2"))
  1.083684 seconds (1.04 M allocations: 63.173 MiB, 0.86% gc time, 99.98% compilation time)
```

After:

```
julia> @time @eval collect(JuliaSyntax.Tokenize.Lexer("1+1 == 2"))
  0.016808 seconds (29.64 k allocations: 1.939 MiB, 62.47% compilation
```

cc @timholy 