### PR TITLE
Parse docstring attachment as `K"doc"` kind

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -44,8 +44,6 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
                       val isa UInt128 ? Symbol("@uint128_str") :
                       Symbol("@big_str")
             return Expr(:macrocall, GlobalRef(Core, macname), nothing, str)
-        elseif kind(node) == K"core_@doc"
-            return GlobalRef(Core, Symbol("@doc"))
         elseif kind(node) == K"core_@cmd"
             return GlobalRef(Core, Symbol("@cmd"))
         elseif kind(node) == K"MacroName" && val === Symbol("@.")
@@ -156,6 +154,9 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
     if headsym === :macrocall
         reorder_parameters!(args, 2)
         insert!(args, 2, loc)
+    elseif headsym === :doc
+        return Expr(:macrocall, GlobalRef(Core, Symbol("@doc")),
+                    loc, args...)
     elseif headsym in (:dotcall, :call)
         # Julia's standard `Expr` ASTs have children stored in a canonical
         # order which is often not always source order. We permute the children

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -864,7 +864,6 @@ const _kind_names =
             "MacroName"
             "StringMacroName"
             "CmdMacroName"
-            "core_@doc"
             "core_@cmd"
             "core_@int128_str"
             "core_@uint128_str"

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -117,8 +117,6 @@ function SyntaxNode(source::SourceFile, raw::GreenNode{SyntaxHead}, position::In
             Symbol("@$(normalize_identifier(val_str))_str")
         elseif k == K"CmdMacroName"
             Symbol("@$(normalize_identifier(val_str))_cmd")
-        elseif k == K"core_@doc"
-            Symbol("core_@doc")
         elseif k == K"core_@cmd"
             Symbol("core_@cmd")
         elseif is_syntax_kind(raw)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -295,4 +295,11 @@
                  Expr(:block, LineNumberNode(1), :w),
                  Expr(:block, LineNumberNode(1), :z))
     end
+
+    @testset "Core.@doc" begin
+        @test parse(Expr, "\"x\" f") ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), LineNumberNode(1), "x", :f)
+        @test parse(Expr, "\n\"x\" f") ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), LineNumberNode(2), "x", :f)
+    end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -59,7 +59,7 @@ tests = [
         "a;b;c"   => "(toplevel a b c)"
         "a;;;b;;" => "(toplevel a b)"
         """ "x" a ; "y" b """ =>
-            """(toplevel (macrocall core_@doc (string "x") a) (macrocall core_@doc (string "y") b))"""
+            """(toplevel (doc (string "x") a) (doc (string "y") b))"""
         "x y"  =>  "x (error-t y)"
     ],
     JuliaSyntax.parse_eq => [
@@ -487,7 +487,7 @@ tests = [
         "module do \n end"  =>  "(module true (error (do)) (block))"
         "module \$A end"    =>  "(module true (\$ A) (block))"
         "module A \n a \n b \n end"  =>  "(module true A (block a b))"
-        """module A \n "x"\na\n end""" => """(module true A (block (macrocall core_@doc (string "x") a)))"""
+        """module A \n "x"\na\n end""" => """(module true A (block (doc (string "x") a)))"""
         # export
         "export a"   =>  "(export a)"  => Expr(:export, :a)
         "export @a"  =>  "(export @a)" => Expr(:export, Symbol("@a"))
@@ -912,11 +912,11 @@ tests = [
         """ "notdoc" ]        """ => "(string \"notdoc\")"
         """ "notdoc" \n]      """ => "(string \"notdoc\")"
         """ "notdoc" \n\n foo """ => "(string \"notdoc\")"
-        """ "doc" \n foo      """ => """(macrocall core_@doc (string "doc") foo)"""
-        """ "doc" foo         """ => """(macrocall core_@doc (string "doc") foo)"""
-        """ "doc \$x" foo     """ => """(macrocall core_@doc (string "doc " x) foo)"""
+        """ "doc" \n foo      """ => """(doc (string "doc") foo)"""
+        """ "doc" foo         """ => """(doc (string "doc") foo)"""
+        """ "doc \$x" foo     """ => """(doc (string "doc " x) foo)"""
         # Allow docstrings with embedded trailing whitespace trivia
-        "\"\"\"\n doc\n \"\"\" foo"  => """(macrocall core_@doc (string-s "doc\\n") foo)"""
+        "\"\"\"\n doc\n \"\"\" foo"  => """(doc (string-s "doc\\n") foo)"""
     ],
 ]
 


### PR DESCRIPTION
With this change `"str" f` now parses as

    (doc (string "str") f)

This better represents the surface syntax which isn't an explicit macro call but a juxtaposition at top level.

The lowering to a macro call is done later as part of `Expr` conversion.

Part of #88