### PR TITLE
Basic after-parse tokenization interface

### DIFF
--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -7,7 +7,6 @@ include("kinds.jl")
 
 # Lexing uses a significantly modified version of Tokenize.jl
 include("tokenize.jl")
-using .Tokenize: Token
 
 # Source and diagnostics
 include("source_files.jl")

--- a/test/fuzz_test.jl
+++ b/test/fuzz_test.jl
@@ -1,4 +1,5 @@
 using JuliaSyntax
+using JuliaSyntax: tokenize
 
 # Parser fuzz testing tools.
 
@@ -881,36 +882,6 @@ const cutdown_tokens = [
 
     "√"
 ]
-
-#-------------------------------------------------------------------------------
-
-# Rough tokenization interface.
-# TODO: We should have something like this in parser_api.jl
-
-struct Token2
-    head::JuliaSyntax.SyntaxHead
-    range::UnitRange{UInt32}
-end
-
-function tokenize(text::String)
-    ps = JuliaSyntax.ParseStream(text)
-    JuliaSyntax.parse!(ps, rule=:toplevel)
-    ts = ps.tokens
-    output_tokens = Token2[]
-    for i = 2:length(ts)
-        if JuliaSyntax.kind(ts[i]) == JuliaSyntax.K"TOMBSTONE"
-            continue
-        end
-        r = ts[i-1].next_byte:thisind(text, ts[i].next_byte-1)
-        push!(output_tokens, Token2(JuliaSyntax.head(ts[i]), r))
-    end
-    output_tokens
-end
-
-function split_tokens(text::String)
-    [@view text[t.range] for t in tokenize(text)]
-end
-
 
 #-------------------------------------------------------------------------------
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -27,7 +27,9 @@ using .JuliaSyntax:
     child,
     fl_parseall,
     fl_parse,
-    highlight
+    highlight,
+    tokenize,
+    untokenize
 
 if VERSION < v"1.6"
     # Compat stuff which might not be in Base for older versions

--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -15,7 +15,7 @@ using JuliaSyntax.Tokenize:
     Tokenize,
     tokenize,
     untokenize,
-    Token
+    RawToken
 
 tok(str, i = 1) = collect(tokenize(str))[i]
 
@@ -321,7 +321,7 @@ end
     @test String(take!(io)) == "1-5        String         "
 end
 
-~(tok::Token, t::Tuple) = tok.kind == t[1] && untokenize(tok, t[3]) == t[2]
+~(tok::RawToken, t::Tuple) = tok.kind == t[1] && untokenize(tok, t[3]) == t[2]
 
 @testset "raw strings" begin
     str = raw""" str"x $ \ y" """


### PR DESCRIPTION
Implement a `tokenize()` function which retreives the tokens *after* parsing.

Going through the parser isn't hugely more expensive than plain tokenization, and allows us to be more precise and complete.

For example it automatically:
* Determines when contextual keywords are keywords, vs identifiers. For example, the `outer` in `outer = 1` is an identifier, but a keyword in `for outer i = 1:10`
* Validates numeric literals (eg, detecting overflow cases like `10e1000` and flagging as errors)
* Splits or combines ambiguous tokens. For example, making the `...` in `import ...A` three separate `.` tokens.