### PR TITLE
Enclose grouping parentheses with `parens` node

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -197,6 +197,9 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
         end
     elseif headsym === :where
         reorder_parameters!(args, 2)
+    elseif headsym == :parens
+        # parens are used for grouping and don't appear in the Expr AST
+        return only(args)
     elseif headsym in (:try, :try_finally_catch)
         # Try children in source order:
         #   try_block catch_var catch_block else_block finally_block

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -3,11 +3,7 @@
         @test parse(Expr, " x ") == :x
         @test JuliaSyntax.remove_linenums!(parseall(Expr, " x ")) == Expr(:toplevel, :x)
         @test parseatom(Expr, " x ") == :x
-        # TODO: Fix this situation with trivia here; the brackets are trivia, but
-        # must be parsed to discover the atom inside. But in GreenTree we only
-        # place trivia as siblings of the leaf node with identifier `x`, not as
-        # children.
-        @test_broken parseatom(Expr, "(x)") == :x
+        @test parseatom(Expr, "(x)") == :x
 
         # SubString
         @test parse(Expr, SubString("x+y")) == :(x+y)


### PR DESCRIPTION
Introduce a new kind `K"parens"` to represent grouping parentheses with a tree node of their own. This makes it simple for tooling to process and preserve parenthesized expressions without resorting to searching through the attached syntax trivia.

An alternative considered here was to use `K"block"` with a single child which would avoid introducing an extra kind of node. But in that case we couldn't distinguish between a trivial block like `(a;)` vs bare parentheses `(a)`. It also makes implementing `peek_behind` more complicated.

Part of #88. Helps with #22 and #134