### PR TITLE
Better conversion to `Expr` with `parse(..., ignore_errors=true)`

### DIFF
--- a/test/expr.jl
+++ b/test/expr.jl
@@ -326,4 +326,12 @@
         @test parse(Expr, "baremodule A end") ==
             Expr(:module, false, :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
     end
+
+    @testset "errors" begin
+        @test parse(Expr, "--", ignore_errors=true) ==
+            Expr(:error, "invalid operator: `--`")
+        @test parseall(Expr, "a b", ignore_errors=true) ==
+            Expr(:toplevel, LineNumberNode(1), :a,
+                 LineNumberNode(1), Expr(:error, :b))
+    end
 end


### PR DESCRIPTION
This isn't a complete solution, but it improves the situation somewhat. (It's unclear whether we should spend a lot of effort here as converting to Expr is not a particularly expressive path for error propagation. We probably need to plumb diagnostic support into the Julia runtime in a more general way.)

Supersedes #86