### PR TITLE
Allow parentheses in import paths and macro names

### DIFF
--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -36,7 +36,13 @@ end
 	@test diagnostic("import A .==") ==
         Diagnostic(9, 9, :warning, "space between dots in import path")
 	@test diagnostic("import A.:+") ==
-        Diagnostic(10, 10, :warning, "quoting with `:` in import is unnecessary")
+        Diagnostic(10, 10, :warning, "quoting with `:` is not required here")
+    @test diagnostic("import A.(:+)") ==
+        Diagnostic(10, 13, :warning, "parentheses are not required here")
+    @test diagnostic("export (x)") ==
+        Diagnostic(8, 10, :warning, "parentheses are not required here")
+    @test diagnostic("export :x") == 
+        Diagnostic(8, 9, :error, "expected identifier")
 end
 
 @testset "diagnostics for literal parsing" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -327,11 +327,17 @@
             Expr(:module, false, :A, Expr(:block, LineNumberNode(1), LineNumberNode(1)))
     end
 
+
     @testset "errors" begin
         @test parse(Expr, "--", ignore_errors=true) ==
             Expr(:error, "invalid operator: `--`")
         @test parseall(Expr, "a b", ignore_errors=true) ==
             Expr(:toplevel, LineNumberNode(1), :a,
                  LineNumberNode(1), Expr(:error, :b))
+    end
+
+    @testset "import" begin
+        @test parse(Expr, "import A.(:b).:c: x.:z", ignore_warnings=true) ==
+            Expr(:import, Expr(Symbol(":"), Expr(:., :A, :b, :c), Expr(:., :x, :z)))
     end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -321,6 +321,7 @@ tests = [
         "[@foo x]"     =>  "(vect (macrocall @foo x))"
         "[@foo]"       =>  "(vect (macrocall @foo))"
         "@var\"#\" a"  =>  "(macrocall (var @#) a)"                => Expr(:macrocall, Symbol("@#"), LineNumberNode(1), :a)
+        "@(A) x"       =>  "(macrocall (parens @A) x)"
         "A.@x y"       =>  "(macrocall (. A (quote @x)) y)"
         "A.@var\"#\" a"=>  "(macrocall (. A (quote (var @#))) a)"  => Expr(:macrocall, Expr(:., :A, QuoteNode(Symbol("@#"))), LineNumberNode(1), :a)
         "@+x y"        =>  "(macrocall @+ x y)"

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -649,7 +649,8 @@ tests = [
         "import \$A.@x"  =>  "(import (. (\$ A) @x))"
         "import A.B"  =>  "(import (. A B))"
         "import A.B.C"  =>  "(import (. A B C))"
-        "import A.:+"  =>  "(import (. A +))"
+        "import A.:+"  =>  "(import (. A (quote +)))"
+        "import A.(:+)"=>  "(import (. A (parens (quote +))))"
         "import A.=="  =>  "(import (. A ==))"
         "import A.⋆.f" =>  "(import (. A ⋆ f))"
         "import A..."  =>  "(import (. A ..))"
@@ -942,7 +943,7 @@ parseall_test_specs = [
 
     # The following may not be ideal error recovery! But at least the parser
     # shouldn't crash
-    "@(x y)" => "(toplevel (macrocall (error x (error-t y))))"
+    "@(x y)" => "(toplevel (macrocall (parens @x (error-t y))))"
     "|(&\nfunction" => "(toplevel (call | (& (function (error (error)) (block (error)) (error-t))) (error-t)))"
 ]
 


### PR DESCRIPTION
* Allow parens in import paths like `import A.(:+)`
* Fix parsing of parenthesized macro names in macro calls like `@(A)`