### PR TITLE
Various fixes for `K"parens"` nodes

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -651,6 +651,7 @@ tests = [
         "import A.B.C"  =>  "(import (. A B C))"
         "import A.:+"  =>  "(import (. A (quote +)))"
         "import A.(:+)"=>  "(import (. A (parens (quote +))))"
+        "import A.:(+)" => "(import (. A (quote (parens +))))"
         "import A.=="  =>  "(import (. A ==))"
         "import A.⋆.f" =>  "(import (. A ⋆ f))"
         "import A..."  =>  "(import (. A ..))"


### PR DESCRIPTION
* Fix `:kw` conversion in dubious constructs like `f(((a=1)))`
* Fix Expr conversion for parens which contain an error
* Allow more parens in import paths like `import A.:(==)`