### PR TITLE
Add isascii to normalize_identifier for 25% reduction in parse time

### DIFF
--- a/src/literal_parsing.jl
+++ b/src/literal_parsing.jl
@@ -353,5 +353,6 @@ end
 
 function normalize_identifier(str)
     flags = Base.Unicode.UTF8PROC_STABLE | Base.Unicode.UTF8PROC_COMPOSE
-    utf8proc_map(str, flags)
+    isascii(str) || return utf8proc_map(str, flags)
+    return str
 end

--- a/src/literal_parsing.jl
+++ b/src/literal_parsing.jl
@@ -353,6 +353,5 @@ end
 
 function normalize_identifier(str)
     flags = Base.Unicode.UTF8PROC_STABLE | Base.Unicode.UTF8PROC_COMPOSE
-    isascii(str) || return utf8proc_map(str, flags)
-    return str
+    return isascii(str) ? str : utf8proc_map(str, flags)
 end


### PR DESCRIPTION
I was trying to use JuliaSyntax is some string benchmarking and noticed a lot of calls to utf8_normalization.

In master `isascii` is now blazing fast, so I thought that checking if a string was ascii before any UTF8 bs would speed things up.  Julia code is mostly ascii

I benchmarked by parsing base/abstractarray.jl which is the largest file in the codebase.

Before pr:
```julia
julia> @benchmark t= JuliaSyntax.parseall(JuliaSyntax.SyntaxNode,$f)
BenchmarkTools.Trial: 291 samples with 1 evaluation.
 Range (min … max):  15.019 ms … 25.913 ms  ┊ GC (min … max): 0.00% … 36.31%
 Time  (median):     16.389 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   17.184 ms ±  1.963 ms  ┊ GC (mean ± σ):  4.12% ±  7.50%

       ▂▂▂█▂
  ▃▅▆▇▇█████▇▆▅█▄▃▄▁▄▃▄▁▁▂▃▃▁▁▃▁▆▃▃▃▄▁▄▂▃▃▂▃▃▁▁▃▃▁▂▁▁▂▁▁▁▂▁▁▂ ▃
  15 ms           Histogram: frequency by time        23.9 ms <

 Memory estimate: 7.97 MiB, allocs estimate: 171744.
```

After PR
```julia
julia> @benchmark t= JuliaSyntax.parseall(JuliaSyntax.SyntaxNode,$f)
BenchmarkTools.Trial: 373 samples with 1 evaluation.
 Range (min … max):  11.547 ms … 32.907 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.722 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.422 ms ±  2.064 ms  ┊ GC (mean ± σ):  3.20% ± 6.65%

          ▇█▃
  ▂▂▂▃▅█▇████▆▄▄▄▃▃▄▃▃▂▂▂▃▂▃▃▃▂▄▃▄▂▂▃▂▃▂▃▃▁▁▁▂▂▂▂▁▁▁▁▁▁▁▁▂▁▂▂ ▃
  11.5 ms         Histogram: frequency by time        18.6 ms <

 Memory estimate: 6.48 MiB, allocs estimate: 97785.
```