### PR TITLE
Fix highlighting of empty source ranges

### DIFF
--- a/src/source_files.jl
+++ b/src/source_files.jl
@@ -183,17 +183,18 @@ function highlight(io::IO, source::SourceFile, range::UnitRange;
                             context_lines_before=context_lines_before,
                             context_lines_after=context_lines_inner)
     a,b = source_line_range(source, p)
-    c,d = source_line_range(source, q)
-    z,w = source_line_range(source, q;
+    q1 = max(q, p) # Ignore q for empty ranges
+    c,d = source_line_range(source, q1)
+    z,w = source_line_range(source, q1;
                             context_lines_before=context_lines_inner,
                             context_lines_after=context_lines_after)
 
     p_line = source_line(source, p)
-    q_line   = source_line(source, q)
+    q_line = source_line(source, q)
 
     marker_line_color = :light_black
 
-    if p_line == q_line
+    if p_line >= q_line
         # x-----------------
         # a---p-------q----b
         # #   └───────┘ ── note

--- a/test/source_files.jl
+++ b/test/source_files.jl
@@ -57,11 +57,22 @@ end
         αβγδ
         +-*/""")
 
+    # Empty ranges
+    @test sprint(highlight, src, 1:0) == "abcd\n└\nαβγδ\n+-*/"
+    @test sprint(highlight, src, 2:1) == "abcd\n#└\nαβγδ\n+-*/"
+    @test sprint(highlight, src, 3:2) == "abcd\n# └\nαβγδ\n+-*/"
+    @test sprint(highlight, src, 4:3) == "abcd\n#  └\nαβγδ\n+-*/"
+    @test sprint(highlight, src, 5:4) == "abcd\n#   └\nαβγδ\n+-*/"
+    @test sprint(highlight, src, 6:5) == "abcd\nαβγδ\n└\n+-*/"
+    @test sprint(highlight, src, 19:18) == "abcd\nαβγδ\n+-*/\n#   └"
+    @test sprint(io->highlight(io, src, 1:0, context_lines_after=0, note="hi")) ==
+        "abcd\n└ ── hi"
+
+    # Single line ranges
     @test sprint(highlight, src, 1:4) == "abcd\n└──┘\nαβγδ\n+-*/"
     @test sprint(highlight, src, 2:4) == "abcd\n#└─┘\nαβγδ\n+-*/"
     @test sprint(highlight, src, 3:4) == "abcd\n# └┘\nαβγδ\n+-*/"
     @test sprint(highlight, src, 4:4) == "abcd\n#  ╙\nαβγδ\n+-*/"
-    @test sprint(highlight, src, 4:3) == "abcd\n#  └\nαβγδ\n+-*/"
     @test sprint(highlight, src, 5:5) == "abcd\n#   └\nαβγδ\n+-*/"
 
     # multi-byte chars


### PR DESCRIPTION
Highlighting of empty ranges needs special handling at the ends of lines as the source line of the end of the range can be less than the source line at the start of the range.