### PR TITLE
Simplify child layout for `try`

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -907,8 +907,6 @@ const _kind_names =
         "flatten"
         "comprehension"
         "typed_comprehension"
-        # Special kind for compatibility with the ever-ugly try-finally-catch ordering
-        "try_finally_catch"
     "END_SYNTAX_KINDS"
 ]
 

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -303,6 +303,19 @@
                  Expr(:block, LineNumberNode(1), :y),
                  Expr(:block, LineNumberNode(1), :w),
                  Expr(:block, LineNumberNode(1), :z))
+        # finally before catch
+        @test parse(Expr, "try x finally y catch e z end", ignore_warnings=true) ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 :e,
+                 Expr(:block, LineNumberNode(1), :z),
+                 Expr(:block, LineNumberNode(1), :y))
+        # empty recovery
+        @test parse(Expr, "try x end", ignore_errors=true) ==
+            Expr(:try,
+                 Expr(:block, LineNumberNode(1), :x),
+                 false, false,
+                 Expr(:block, Expr(:error)))
     end
 
     @testset "juxtapose" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -596,24 +596,23 @@ tests = [
     ],
     JuliaSyntax.parse_try => [
         "try \n x \n catch e \n y \n finally \n z end" =>
-            "(try (block x) e (block y) false (block z))"
+            "(try (block x) (catch e (block y)) (finally (block z)))"
         ((v=v"1.8",), "try \n x \n catch e \n y \n else z finally \n w end") =>
-            "(try (block x) e (block y) (block z) (block w))"
-        "try x catch end"       =>  "(try (block x) false (block) false false)"
-        "try x catch ; y end"   =>  "(try (block x) false (block y) false false)"
-        "try x catch \n y end"  =>  "(try (block x) false (block y) false false)"
-        "try x catch e y end"   =>  "(try (block x) e (block y) false false)"
-        "try x catch \$e y end" =>  "(try (block x) (\$ e) (block y) false false)"
-        "try x catch e+3 y end" =>  "(try (block x) (error (call-i e + 3)) (block y) false false)"
-        "try x finally y end"   =>  "(try (block x) false false false (block y))"
+            "(try (block x) (catch e (block y)) (else (block z)) (finally (block w)))"
+        "try x catch end"       =>  "(try (block x) (catch false (block)))"
+        "try x catch ; y end"   =>  "(try (block x) (catch false (block y)))"
+        "try x catch \n y end"  =>  "(try (block x) (catch false (block y)))"
+        "try x catch e y end"   =>  "(try (block x) (catch e (block y)))"
+        "try x catch \$e y end" =>  "(try (block x) (catch (\$ e) (block y)))"
+        "try x catch e+3 y end" =>  "(try (block x) (catch (error (call-i e + 3)) (block y)))"
+        "try x finally y end"   =>  "(try (block x) (finally (block y)))"
         # v1.8 only
-        ((v=v"1.8",), "try catch ; else end") => "(try (block) false (block) (block) false)"
-        ((v=v"1.8",), "try else x finally y end") => "(try (block) false false (error (block x)) (block y))"
-        ((v=v"1.7",), "try catch ; else end")  =>  "(try (block) false (block) (error (block)) false)"
+        ((v=v"1.8",), "try catch ; else end") => "(try (block) (catch false (block)) (else (block)))"
+        ((v=v"1.8",), "try else x finally y end") => "(try (block) (else (error (block x))) (finally (block y)))"
+        ((v=v"1.7",), "try catch ; else end")  =>  "(try (block) (catch false (block)) (else (error (block))))"
         # finally before catch :-(
-        "try x finally y catch e z end"  =>  "(try_finally_catch (block x) false false false (block y) e (block z))" =>
-            Expr(:try, Expr(:block, :x), :e, Expr(:block, :z), Expr(:block, :y))
-        "try x end" => "(try (block x) false false false false (error-t))"
+        "try x finally y catch e z end"  =>  "(try (block x) (finally (block y)) (catch e (block z)))"
+        "try x end" => "(try (block x) (error-t))"
     ],
     JuliaSyntax.parse_imports => [
         "import A as B: x"  => "(import (: (error (as (. A) B)) (. x)))"

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -81,7 +81,7 @@
         parseshow(s;kws...) = sprint(show, MIME("text/x.sexpression"), parse(SyntaxNode, s; kws...))
         @test_throws JuliaSyntax.ParseError parseshow("try finally catch ex end")
         @test parseshow("try finally catch ex end", ignore_warnings=true) ==
-            "(try_finally_catch (block) false false false (block) ex (block))"
+            "(try (block) (finally (block)) (catch ex (block)))"
         # ignore_errors
         @test_throws JuliaSyntax.ParseError parseshow("[a; b, c]")
         @test_throws JuliaSyntax.ParseError parseshow("[a; b, c]", ignore_warnings=true)


### PR DESCRIPTION
The child layout of try-catch-else-finally is awkward because several of the subclauses are optional. Particularly this has led to problems for `else` in `Expr` which needed to be tacked onto the end for compatibility.

This change clarifies the situation a bit and makes it more future proof by wrapping the subclauses in their own expression heads.

Part of #88