### PR TITLE
Add parens node in special cases `:(=)` and `:(::)`

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -783,8 +783,9 @@ tests = [
         "[x=1, y=2]"    =>  "(vect (= x 1) (= y 2))"
         "[x=1, ; y=2]"  =>  "(vect (= x 1) (parameters (= y 2)))"
         # parse_paren
-        ":(=)"  =>  "(quote =)"
-        ":(::)"  =>  "(quote ::)"
+        ":(=)"  =>  "(quote (parens =))"
+        ":(::)"  =>  "(quote (parens ::))"
+        ":(::\n)" => "(quote (parens ::))"
         "(function f \n end)" => "(parens (function f))"
         # braces
         "{x y}"      =>  "(bracescat (row x y))"


### PR DESCRIPTION
Minor fixes for special cases forgotten from #222