### PR TITLE
Big cleanup of test case reduction utilities

### DIFF
--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -25,23 +25,21 @@ end
 
 base_tests_path = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
 @testset "Parse Base tests at $base_tests_path" begin
-    for f in find_source_in_path(base_tests_path)
-        @testset "Parse $(relpath(f, base_tests_path))" begin
-            # In julia-1.6, test/copy.jl had spurious syntax which became the
-            # multidimensional array syntax in 1.7.
-            endswith(f, "copy.jl") && v"1.6" <= VERSION < v"1.7" && continue
-
-            # syntax.jl has some intentially weird syntax which we parse
-            # differently than the flisp parser, and some cases which we've
-            # decided are syntax errors.
-            endswith(f, "syntax.jl") && continue
-
-            @test parsers_agree_on_file(f)
-            # TODO:
-            # exprs_equal = endswith(f, "syntax.jl") ?
-            #               exprs_roughly_equal : exprs_equal_no_linenum
-            # @test parsers_agree_on_file(f; exprs_equal=exprs_equal)
+    test_parse_all_in_path(base_tests_path) do f
+        # In julia-1.6, test/copy.jl had spurious syntax which became the
+        # multidimensional array syntax in 1.7.
+        if endswith(f, "copy.jl") && v"1.6" <= VERSION < v"1.7"
+            return false
         end
+
+        # syntax.jl has some intentially weird syntax which we parse
+        # differently than the flisp parser, and some cases which we've
+        # decided are syntax errors.
+        if endswith(f, "syntax.jl")
+            return false
+        end
+
+        return true
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using JuliaSyntax: GreenNode, SyntaxNode,
     children, child, setchild!, SyntaxHead
 
 include("test_utils.jl")
+include("fuzz_test.jl")
 
 # Tests for the test_utils go here to allow the utils to be included on their
 # own without invoking the tests.


### PR DESCRIPTION
* Text-based test reduction moved into test_utils
* Remove some obsolete utils
* Rename reduction utils to something more sensible
* List actual reduced failures in package parsing tests