### PR TITLE
Minor fixes to test tools

### DIFF
--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -38,7 +38,7 @@ Logging.with_logger(TerminalLogger()) do
                         println(io, "\n")
                     end
                 end
-                reduced_failures = reduce_text.(sourcetext.(reduce_tree(text)),
+                reduced_failures = reduce_text.(reduce_tree(text),
                                                 parsers_fuzzy_disagree)
                 append!(all_reduced_failures, reduced_failures)
                 @error("Parsers succeed but disagree",


### PR DESCRIPTION
* Avoid crash in heuristic Expr comparisons
* reduce_tree(text) returns text not a tree