### PR TITLE
Add braces node around `T` in `x where {T}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ the source text more closely.
 
 * `K"macrocall"` - allow users to easily distinguish macrocalls with parentheses from those without them (#218)
 * Grouping parentheses are represented with a node of kind `K"parens"` (#222)
+* The right hand side of `x where {T}` retains the `K"braces"` node around the `T` to distinguish it from `x where T`.
 * Ternary syntax is not immediately lowered to an `if` node: `a ? b : c` parses as `(? a b c)` rather than `Expr(:if, :a, :b, :c)` (#85)
 * `global const` and `const global` are not normalized by the parser. This is done in `Expr` conversion (#130)
 * The AST for `do` is flatter and not lowered to a lambda by the parser: `f(x) do y ; body end` is parsed as `(do (call f x) (tuple y) (block body))` (#98)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -212,7 +212,11 @@ function _to_expr(node::SyntaxNode; iteration_spec=false, need_linenodes=true,
             end
         end
     elseif headsym === :where
-        reorder_parameters!(args, 2)
+        if length(args) == 2 && Meta.isexpr(args[2], :braces)
+            a2 = args[2].args
+            reorder_parameters!(a2, 2)
+            args = Any[args[1], a2...]
+        end
     elseif headsym === :parens
         # parens are used for grouping and don't appear in the Expr AST
         if length(args) == 1

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -317,6 +317,9 @@
     end
 
     @testset "where" begin
+        @test parsestmt(Expr, "A where T") == Expr(:where, :A, :T)
+        @test parsestmt(Expr, "A where {T}") == Expr(:where, :A, :T)
+        @test parsestmt(Expr, "A where {S, T}") == Expr(:where, :A, :S, :T)
         @test parsestmt(Expr, "A where {X, Y; Z}") == Expr(:where, :A, Expr(:parameters, :Z), :X, :Y)
     end
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -287,8 +287,8 @@ tests = [
         # compatible with the reference parser (see #248)
         "+ <: A where B"  =>  "(where (call-pre + (<:-pre A)) B)"
         # Really for parse_where
-        "x where \n {T}"  =>  "(where x T)"
-        "x where {T,S}"  =>  "(where x T S)"
+        "x where \n {T}"  =>  "(where x (braces T))"
+        "x where {T,S}"  =>  "(where x (braces T S))"
         "x where {T S}"  =>  "(where x (bracescat (row T S)))"
         "x where {y for y in ys}"  =>  "(where x (braces (generator y (= y ys))))"
         "x where T"  =>  "(where x T)"
@@ -578,7 +578,7 @@ tests = [
         "function f body end"    =>  "(function (error f) (block body))"
         "function f()::T    end" =>  "(function (::-i (call f) T) (block))"
         "function f()::g(T) end" =>  "(function (::-i (call f) (call g T)) (block))"
-        "function f() where {T} end"  => "(function (where (call f) T) (block))"
+        "function f() where {T} end"  => "(function (where (call f) (braces T)) (block))"
         "function f() where T   end"  => "(function (where (call f) T) (block))"
         "function f()::S where T end" => "(function (where (::-i (call f) S) T) (block))"
         # Ugly cases for compat where extra parentheses existed and we've


### PR DESCRIPTION
This allows `x where T` to be distinguished from `x where {T}` easily which should be quite helpful for source formatting tooling. It's also more consistent with the other allowed (but weird) forms such as `x where {T S}`.

Fixes one of the more interesting cases in #223 