### PR TITLE
Remove `K"parens"` from `SyntaxNode`

### DIFF
--- a/test/expr.jl
+++ b/test/expr.jl
@@ -472,6 +472,12 @@
             Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), LineNumberNode(2), "x", :f)
     end
 
+    @testset "Large integer macros" begin
+        @test parsestmt(Expr, "(0x00000000000000001)") ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@uint128_str")),
+                 "0x00000000000000001")
+    end
+
     @testset "return" begin
         @test parsestmt(Expr, "return x") == Expr(:return, :x)
         @test parsestmt(Expr, "return")  == Expr(:return, nothing)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -7,7 +7,7 @@ function parse_to_sexpr_str(production, code::AbstractString; v=v"1.6", expr=fal
     JuliaSyntax.validate_tokens(stream)
     t = build_tree(GreenNode, stream, wrap_toplevel_as_kind=K"None")
     source = SourceFile(code)
-    s = SyntaxNode(source, t)
+    s = SyntaxNode(source, t, keep_parens=true)
     if expr
         JuliaSyntax.remove_linenums!(Expr(s))
     else


### PR DESCRIPTION
One approach to fix #239:

* Add a `head` field to `SyntaxNode` to separate it from `GreenNode`
* When a `K"parens"` node is encountered in the green tree, replace it with its child.
* However, have the replacement point to the parens `GreenNode` so we can still observe parentheses

This turns out to work, but is awkward.  It's especially awkward/surprising for `sourcetext`, as we have things like

```julia
julia> kind(parsestmt(SyntaxNode, "(10)"))
K"Integer"

julia> sourcetext(parsestmt(SyntaxNode, "(10)"))
"(10)"
```

We could fix `sourcetext()` to avoid this inconsistency at the cost of traversing the raw tree dynamically.  But then do we also need to change `range()`?

Overall this approach is not feeling great to me.