### PR TITLE
Remove `K"parens"` from `SyntaxNode`

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -77,7 +77,7 @@ end
 
 function _parse(rule::Symbol, need_eof::Bool, ::Type{T}, text, index=1; version=VERSION,
                 ignore_trivia=true, filename=nothing, first_line=1, ignore_errors=false,
-                ignore_warnings=ignore_errors) where {T}
+                ignore_warnings=ignore_errors, kws...) where {T}
     stream = ParseStream(text, index; version=version)
     if ignore_trivia && rule != :all
         bump_trivia(stream, skip_newlines=true)
@@ -99,7 +99,7 @@ function _parse(rule::Symbol, need_eof::Bool, ::Type{T}, text, index=1; version=
     # * It's kind of required for GreenNode, as GreenNode only records spans,
     #   not absolute positions.
     # * Dropping it would be ok for SyntaxNode and Expr...
-    tree = build_tree(T, stream; wrap_toplevel_as_kind=K"toplevel", filename=filename, first_line=first_line)
+    tree = build_tree(T, stream; wrap_toplevel_as_kind=K"toplevel", filename=filename, first_line=first_line, kws...)
     tree, last_byte(stream) + 1
 end
 

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -5,9 +5,9 @@
              (s; kws...) -> JuliaSyntax.parsestmt(Expr, s; kws...),
              (s; kws...) -> JuliaSyntax.parseall(Expr, s; kws...))
         else
-            ((s; kws...) -> Expr(JuliaSyntax.parseatom(SyntaxNode, s; kws...)),
-             (s; kws...) -> Expr(JuliaSyntax.parsestmt(SyntaxNode, s; kws...)),
-             (s; kws...) -> Expr(JuliaSyntax.parseall(SyntaxNode, s; kws...)))
+            ((s; kws...) -> Expr(JuliaSyntax.parseatom(SyntaxNode, s; keep_parens=true, kws...)),
+             (s; kws...) -> Expr(JuliaSyntax.parsestmt(SyntaxNode, s; keep_parens=true, kws...)),
+             (s; kws...) -> Expr(JuliaSyntax.parseall(SyntaxNode, s; keep_parens=true, kws...)))
         end
 
     @testset "Quote nodes" begin
@@ -532,6 +532,16 @@
     @testset "return" begin
         @test parsestmt("return x") == Expr(:return, :x)
         @test parsestmt("return")  == Expr(:return, nothing)
+    end
+
+    @testset "Large integer macros" begin
+        @test parsestmt("0x00000000000000001") ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@uint128_str")),
+                 nothing, "0x00000000000000001")
+
+        @test parsestmt("(0x00000000000000001)") ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@uint128_str")),
+                 nothing, "0x00000000000000001")
     end
 
     @testset "struct" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -7,7 +7,7 @@ function parse_to_sexpr_str(production, code::AbstractString; v=v"1.6", expr=fal
     JuliaSyntax.validate_tokens(stream)
     t = build_tree(GreenNode, stream, wrap_toplevel_as_kind=K"None")
     source = SourceFile(code)
-    s = SyntaxNode(source, t)
+    s = SyntaxNode(source, t, keep_parens=true)
     if expr
         JuliaSyntax.remove_linenums!(Expr(s))
     else


### PR DESCRIPTION
Another approach to fix #239.

Elide all `K"parens"` nodes from the `SyntaxNode` tree, replacing them with their single child.

With #268 merged, this approach works more neatly and doesn't have the downsides of #265.

Close #265