### PR TITLE
Small fix for `Expr(:incomplete)` detection

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -33,7 +33,7 @@ function _incomplete_tag(n::SyntaxNode, codelen)
     i,c = _first_error(n)
     if isnothing(c) || last_byte(c) < codelen || codelen == 0
         return :none
-    elseif first_byte(c) < codelen
+    elseif first_byte(c) <= codelen
         if kind(c) == K"ErrorEofMultiComment" && last_byte(c) == codelen
             # This is the one weird case where the token itself is an
             # incomplete error

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -106,6 +106,8 @@
                 ")"            => :none
                 "1))"          => :none
                 "a b"          => :none
+                "()x"          => :none
+                "."            => :none
             ]
             @testset "$(repr(str))" begin
                 @test Base.incomplete_tag(Meta.parse(str, raise=false)) == tag


### PR DESCRIPTION
This off-by-one error prevented incomplete detection from working for trailing single-character error tokens