### PR TITLE
Reference parser compat: Make toplevel error Exprs more compatible

### DIFF
--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -29,6 +29,19 @@
         @test err.source.first_line == 2
     end
 
+    @testset "toplevel errors" begin
+        ex = JuliaSyntax._core_parser_hook("a\nb\n[x,\ny)", "somefile", 1, 0, :all)[1]
+        @test ex.head == :toplevel
+        @test ex.args[1:5] == [
+            LineNumberNode(1, "somefile"),
+            :a,
+            LineNumberNode(2, "somefile"),
+            :b,
+            LineNumberNode(4, "somefile"),
+        ]
+        @test Meta.isexpr(ex.args[6], :error)
+    end
+
     @testset "enable_in_core!" begin
         JuliaSyntax.enable_in_core!()
 


### PR DESCRIPTION
When encountering a toplevel error, the reference parser
* truncates the top level expression arg list before that error
* includes the last line number
* appends the error message

Do something similar here so that the associated `LoadError` shows a more reasonable line number.