### PR TITLE
Fix for block-vs-parameters in prefix call syntax

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1230,9 +1230,12 @@ function parse_unary(ps::ParseState)
 
         mark_before_paren = position(ps)
         bump(ps, TRIVIA_FLAG) # (
-        _is_paren_call = peek(ps, skip_newlines=true) in KSet"; )"
+        initial_semi = peek(ps, skip_newlines=true) == K";"
         opts = parse_brackets(ps, K")") do had_commas, had_splat, num_semis, num_subexprs
-            is_paren_call = had_commas || had_splat || _is_paren_call
+            is_paren_call = had_commas || had_splat               ||
+                            (initial_semi && num_subexprs > 0)    ||
+                            (initial_semi && num_semis == 1)      ||
+                            (num_semis == 0 && num_subexprs == 0)
             return (needs_parameters=is_paren_call,
                     is_paren_call=is_paren_call,
                     is_block=!is_paren_call && num_semis > 0)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -226,8 +226,11 @@ tests = [
         "+(a...)"  =>  "(call + (... a))"
         "+(a;b,c)" =>  "(call + a (parameters b c))"
         "+(;a)"    =>  "(call + (parameters a))"
+        "+(;;a)"   =>  "(call + (parameters) (parameters a))"
         "+()"      =>  "(call +)"
         "+(\n;a)"  =>  "(call + (parameters a))"
+        "+(;)"     =>  "(call + (parameters))"
+        "+(\n;\n)" =>  "(call + (parameters))"
         "+(\n)"    =>  "(call +)"
         # Whitespace not allowed before prefix function call bracket
         "+ (a,b)"  =>  "(call + (error) a b)"
@@ -238,6 +241,11 @@ tests = [
         # Unary function calls with brackets as grouping, not an arglist
         ".+(a)"   =>  "(dotcall-pre + (parens a))"
         "+(a;b)"  =>  "(call-pre + (block-p a b))"
+        "+(;;)"   =>  "(call-pre + (block-p))"
+        "+(;;)"   =>  "(call-pre + (block-p))"
+        "+(a;)"   =>  "(call-pre + (block-p a))"
+        "+(a;;)"  =>  "(call-pre + (block-p a))"
+        "+(\n;\n;\n)" =>  "(call-pre + (block-p))"
         "+(a=1)"  =>  "(call-pre + (parens (= a 1)))"
         # Unary operators have lower precedence than ^
         "+(a)^2"  =>  "(call-pre + (call-i (parens a) ^ 2))"


### PR DESCRIPTION
Expressions like `+(;;)` are ambiguous between parsing as prefix calls with an empty block, vs normal parenthesized calls with multiple parameters:

    (call-pre + (block))
    (call + (parameters) (parameters))

Fix a few of these cases to use the same somewhat arbitrary disambiguation as the reference parser.