### PR TITLE
Fixes for short form function locations

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -179,13 +179,6 @@ function _fixup_Expr_children!(head, loc, args)
         elseif k == K"let" && i == 1 && @isexpr(arg, :block)
             filter!(a -> !(a isa LineNumberNode), arg.args)
         end
-        if !(k == K"for" && i == 1) && @isexpr(arg, :(=))
-            aa2 = arg.args[2]
-            if is_eventually_call(arg.args[1]) && !@isexpr(aa2, :block)
-                # Add block for short form function locations
-                arg.args[2] = Expr(:block, loc, aa2)
-            end
-        end
         args[i] = arg
     end
     return args
@@ -212,6 +205,12 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
 
     if k == K"?"
         headsym = :if
+    elseif k == K"=" && !is_decorated(head)
+        a2 = args[2]
+        if is_eventually_call(args[1]) && !@isexpr(a2, :block)
+            # Add block for short form function locations
+            args[2] = Expr(:block, loc, a2)
+        end
     elseif k == K"macrocall"
         _reorder_parameters!(args, 2)
         insert!(args, 2, loc)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -590,12 +590,14 @@ function parse_assignment_with_initial_ex(ps::ParseState, mark, down::T) where {
         # [a ~ b c]  ==>  (hcat (call-i a ~ b) c)
         # [a~b]      ==>  (vect (call-i a ~ b))
         bump_dotsplit(ps)
+        bump_trivia(ps)
         parse_assignment(ps, down)
         emit(ps, mark, is_dotted(t) ? K"dotcall" : K"call", INFIX_FLAG)
     else
         # a += b  ==>  (+= a b)
         # a .= b  ==>  (.= a b)
         bump(ps, TRIVIA_FLAG)
+        bump_trivia(ps)
         parse_assignment(ps, down)
         emit(ps, mark, k, flags(t))
     end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -168,14 +168,24 @@
                  Expr(:block,
                       LineNumberNode(1),
                       :xs))
-        # flisp parser quirk: In a for loop the block is not added, despite
-        # this defining a short-form function.
-        @test parsestmt("for f() = xs\nend") ==
-            Expr(:for,
-                 Expr(:(=), Expr(:call, :f), :xs),
+
+        @test parsestmt("let f(x) =\ng(x)=1\nend") ==
+            Expr(:let,
+                 Expr(:(=),
+                      Expr(:call, :f, :x),
+                      Expr(:block,
+                           LineNumberNode(1),
+                           Expr(:(=),
+                               Expr(:call, :g, :x),
+                               Expr(:block,
+                                    LineNumberNode(2),
+                                    1)))),
                  Expr(:block,
-                      LineNumberNode(1)
-                     ))
+                      LineNumberNode(3)))
+
+        # `.=` doesn't introduce short form functions
+        @test parsestmt("f() .= xs") ==
+            Expr(:(.=), Expr(:call, :f), :xs)
     end
 
     @testset "for" begin

--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -29,17 +29,22 @@ base_tests_path = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
         # In julia-1.6, test/copy.jl had spurious syntax which became the
         # multidimensional array syntax in 1.7.
         if endswith(f, "copy.jl") && v"1.6" <= VERSION < v"1.7"
-            return false
+            return nothing
         end
 
         # syntax.jl has some intentially weird syntax which we parse
         # differently than the flisp parser, and some cases which we've
         # decided are syntax errors.
         if endswith(f, "syntax.jl")
-            return false
+            return nothing
         end
 
-        return true
+        if endswith(f, "core.jl")
+            # Loose comparison due to `for f() = 1:3` syntax
+            return exprs_roughly_equal
+        end
+
+        return exprs_equal_no_linenum
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,40 +8,8 @@ using JuliaSyntax: GreenNode, SyntaxNode,
     children, child, setchild!, SyntaxHead
 
 include("test_utils.jl")
+include("test_utils_tests.jl")
 include("fuzz_test.jl")
-
-# Tests for the test_utils go here to allow the utils to be included on their
-# own without invoking the tests.
-@testset "Reference parser bugs" begin
-    # `global (x,y)`
-    @test exprs_roughly_equal(Expr(:global, :x, :y),
-                              Expr(:global, Expr(:tuple, :x, :y)))
-    @test exprs_roughly_equal(Expr(:local, :x, :y),
-                              Expr(:local, Expr(:tuple, :x, :y)))
-    # `0x1.8p0f`
-    @test exprs_roughly_equal(1.5,
-                              Expr(:call, :*, 1.5, :f))
-    @test exprs_roughly_equal(1.5,
-                              Expr(:call, :*, 1.5, :f0))
-    # `@f(a=1) do \n end`
-    @test exprs_roughly_equal(Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:kw, :a, 1)),
-                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))),
-                              Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:(=), :a, 1)),
-                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))))
-    # `"""\n  a\n \n  b"""`
-    @test exprs_roughly_equal("a\n \nb", " a\n\n b")
-    @test !exprs_roughly_equal("a\n x\nb", " a\n x\n b")
-    @test exprs_roughly_equal("a\n x\nb", "a\n x\nb")
-    # `(a; b,)`
-    @test exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
-                              Expr(:tuple, Expr(:parameters, :b), :a))
-    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
-                               Expr(:tuple, Expr(:parameters, :c), :a))
-    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
-                               Expr(:tuple, Expr(:parameters, :b), :c))
-    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b, :c),
-                               Expr(:tuple, Expr(:parameters, :b), :a))
-end
 
 include("utils.jl")
 

--- a/test/test_utils_tests.jl
+++ b/test/test_utils_tests.jl
@@ -1,0 +1,43 @@
+# Tests for the test_utils go here to allow the utils to be included on their
+# own without invoking the tests.
+@testset "Reference parser bugs" begin
+    # `global (x,y)`
+    @test exprs_roughly_equal(Expr(:global, :x, :y),
+                              Expr(:global, Expr(:tuple, :x, :y)))
+    @test exprs_roughly_equal(Expr(:local, :x, :y),
+                              Expr(:local, Expr(:tuple, :x, :y)))
+    # `0x1.8p0f`
+    @test exprs_roughly_equal(1.5,
+                              Expr(:call, :*, 1.5, :f))
+    @test exprs_roughly_equal(1.5,
+                              Expr(:call, :*, 1.5, :f0))
+    # `@f(a=1) do \n end`
+    @test exprs_roughly_equal(Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:kw, :a, 1)),
+                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))),
+                              Expr(:do, Expr(:macrocall, Symbol("@f"), LineNumberNode(1), Expr(:(=), :a, 1)),
+                                   Expr(:->, Expr(:tuple), Expr(:block, LineNumberNode(1)))))
+    # `"""\n  a\n \n  b"""`
+    @test exprs_roughly_equal("a\n \nb", " a\n\n b")
+    @test !exprs_roughly_equal("a\n x\nb", " a\n x\n b")
+    @test exprs_roughly_equal("a\n x\nb", "a\n x\nb")
+    # `(a; b,)`
+    @test exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
+                              Expr(:tuple, Expr(:parameters, :b), :a))
+    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
+                               Expr(:tuple, Expr(:parameters, :c), :a))
+    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b),
+                               Expr(:tuple, Expr(:parameters, :b), :c))
+    @test !exprs_roughly_equal(Expr(:block, :a, LineNumberNode(1), :b, :c),
+                               Expr(:tuple, Expr(:parameters, :b), :a))
+
+    # Line numbers for short form function defs in `for` :-(
+    @test exprs_roughly_equal(Expr(:for, Expr(:(=),
+                                              Expr(:call, :f),
+                                              1),
+                                   Expr(:block, LineNumberNode(1))),
+                              Expr(:for, Expr(:(=),
+                                              Expr(:call, :f),
+                                              Expr(:block, LineNumberNode(1), 1)),
+                                   Expr(:block, LineNumberNode(1))))
+end
+


### PR DESCRIPTION
* Bump trivia after `=` so we see the correct line for functions in multiple-assignments like `let f(x) =\ng(x)=1\nend`
* Fixes for insertion of these line numbers on the right hand side
* Remove special case avoiding inserting short form function location when in `for` loop iteration spec; allow this in Expr comparison instead.

Part of #270