### PR TITLE
Disallow juxtaposition of strings with blocks

### DIFF
--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -592,12 +592,15 @@ end
 # * parens nodes
 # * deleted tokens (TOMBSTONE)
 # * whitespace (if skip_trivia=true)
-function peek_behind_pos(stream::ParseStream; skip_trivia::Bool=true)
+function peek_behind_pos(stream::ParseStream; skip_trivia::Bool=true,
+                         skip_parens::Bool=true)
     token_index = lastindex(stream.tokens)
     range_index = lastindex(stream.ranges)
-    while range_index >= firstindex(stream.ranges) &&
-            kind(stream.ranges[range_index]) == K"parens"
-        range_index -= 1
+    if skip_parens
+        while range_index >= firstindex(stream.ranges) &&
+                kind(stream.ranges[range_index]) == K"parens"
+            range_index -= 1
+        end
     end
     last_token_in_nonterminal = range_index == 0 ? 0 :
                                 stream.ranges[range_index].last_token
@@ -611,8 +614,8 @@ function peek_behind_pos(stream::ParseStream; skip_trivia::Bool=true)
     return ParseStreamPosition(token_index, range_index)
 end
 
-function peek_behind(stream::ParseStream; skip_trivia::Bool=true)
-    peek_behind(stream, peek_behind_pos(stream; skip_trivia=skip_trivia))
+function peek_behind(stream::ParseStream; kws...)
+    peek_behind(stream, peek_behind_pos(stream; kws...))
 end
 
 #-------------------------------------------------------------------------------

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -180,14 +180,19 @@ tests = [
         "(2)(3)x"    => "(juxtapose (parens 2) (parens 3) x)"
         "(x-1)y"     => "(juxtapose (parens (call-i x - 1)) y)"
         "x'y"        => "(juxtapose (call-post x ') y)"
+        "1√x"        =>  "(juxtapose 1 (call-pre √ x))"
         # errors
         "\"a\"\"b\"" => "(juxtapose (string \"a\") (error-t) (string \"b\"))"
         "\"a\"x"     => "(juxtapose (string \"a\") (error-t) x)"
+        "\"\$y\"x"   => "(juxtapose (string y) (error-t) x)"
+        "\"a\"begin end" => "(juxtapose (string \"a\") (error-t) (block))"
         # Not juxtaposition - parse_juxtapose will consume only the first token.
         "x.3"       =>  "x"
-        "sqrt(2)2"  =>  "(call sqrt 2)"
+        "f(2)2"     =>  "(call f 2)"
         "x' y"      =>  "(call-post x ')"
         "x 'y"      =>  "x"
+        "x@y"       =>  "x"
+        "(begin end)x" => "(parens (block))"
     ],
     JuliaSyntax.parse_unary => [
         ":T"       => "(quote-: T)"


### PR DESCRIPTION
Disallow syntax like `"a"begin end`. Add a few more tests for juxtapositon.

Part of #270