### PR TITLE
More precise errors for bad unicode characters

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -23,6 +23,8 @@ const _kind_names =
         "ErrorNumericOverflow"
         "ErrorInvalidEscapeSequence"
         "ErrorOverLongCharacter"
+        "ErrorInvalidUTF8"
+        "ErrorInvisibleChar"
         "ErrorUnknownCharacter"
         # Generic error
         "error"
@@ -1044,6 +1046,8 @@ const _nonunique_kind_names = Set([
     K"ErrorNumericOverflow"
     K"ErrorInvalidEscapeSequence"
     K"ErrorOverLongCharacter"
+    K"ErrorInvalidUTF8"
+    K"ErrorInvisibleChar"
     K"ErrorUnknownCharacter"
     K"ErrorInvalidOperator"
 
@@ -1091,6 +1095,8 @@ const _token_error_descriptions = Dict{Kind, String}(
     K"ErrorNumericOverflow"=>"overflow in numeric literal",
     K"ErrorInvalidEscapeSequence"=>"invalid string escape sequence",
     K"ErrorOverLongCharacter"=>"character literal contains multiple characters",
+    K"ErrorInvalidUTF8"=>"invalid UTF-8 character",
+    K"ErrorInvisibleChar"=>"invisible character",
     K"ErrorUnknownCharacter"=>"unknown unicode character",
     K"ErrorInvalidOperator" => "invalid operator",
     K"Error**" => "use `x^y` instead of `x**y` for exponentiation, and `x...` instead of `**x` for splatting",

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -947,8 +947,12 @@ function validate_tokens(stream::ParseStream)
             end
         elseif is_error(k) && k != K"error"
             # Emit messages for non-generic token errors
-            emit_diagnostic(stream, tokrange,
-                            error=_token_error_descriptions[k])
+            msg = if k in KSet"ErrorInvalidUTF8 ErrorInvisibleChar ErrorUnknownCharacter"
+                "$(_token_error_descriptions[k]) $(repr(text[fbyte]))"
+            else
+                _token_error_descriptions[k]
+            end
+            emit_diagnostic(stream, tokrange, error=msg)
         end
         if error_kind != K"None"
             toks[i] = SyntaxToken(SyntaxHead(error_kind, EMPTY_FLAGS),

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -12,7 +12,13 @@ function diagnostic(str; only_first=false, allow_multiple=false)
 end
 
 @testset "token errors" begin
-    @test diagnostic(":⥻") == Diagnostic(2, 4, :error, "unknown unicode character")
+    @test diagnostic("a\xf5b") == Diagnostic(2, 2, :error, "invalid UTF-8 character '\\xf5'")
+    for c in ['\u00ad', '\u200b', '\u200c', '\u200d',
+              '\u200e', '\u200f', '\u2060', '\u2061']
+        @test diagnostic("a$(c)b") ==
+            Diagnostic(2, 1+sizeof(string(c)), :error, "invisible character $(repr(c))")
+    end
+    @test diagnostic(":⥻") == Diagnostic(2, 4, :error, "unknown unicode character '⥻'")
 end
 
 @testset "parser errors" begin


### PR DESCRIPTION
Ported from equivalent errors in the reference parser

Part of #270 