### PR TITLE
Disallow unbalanced bidirectional unicode

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -26,6 +26,7 @@ const _kind_names =
         "ErrorInvalidUTF8"
         "ErrorInvisibleChar"
         "ErrorUnknownCharacter"
+        "ErrorBidiFormatting"
         # Generic error
         "error"
     "END_ERRORS"
@@ -1049,6 +1050,7 @@ const _nonunique_kind_names = Set([
     K"ErrorInvalidUTF8"
     K"ErrorInvisibleChar"
     K"ErrorUnknownCharacter"
+    K"ErrorBidiFormatting"
     K"ErrorInvalidOperator"
 
     K"Integer"
@@ -1098,6 +1100,7 @@ const _token_error_descriptions = Dict{Kind, String}(
     K"ErrorInvalidUTF8"=>"invalid UTF-8 character",
     K"ErrorInvisibleChar"=>"invisible character",
     K"ErrorUnknownCharacter"=>"unknown unicode character",
+    K"ErrorBidiFormatting"=>"unbalanced bidirectional unicode formatting",
     K"ErrorInvalidOperator" => "invalid operator",
     K"Error**" => "use `x^y` instead of `x**y` for exponentiation, and `x...` instead of `**x` for splatting",
     K"error" => "unknown error token",

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -949,6 +949,8 @@ function validate_tokens(stream::ParseStream)
             # Emit messages for non-generic token errors
             msg = if k in KSet"ErrorInvalidUTF8 ErrorInvisibleChar ErrorUnknownCharacter"
                 "$(_token_error_descriptions[k]) $(repr(text[fbyte]))"
+            elseif k == K"ErrorBidiFormatting"
+                "$(_token_error_descriptions[k]) $(repr(text[fbyte:prevind(text, nbyte)]))"
             else
                 _token_error_descriptions[k]
             end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3282,6 +3282,9 @@ function parse_string(ps::ParseState, raw::Bool)
                 first_chunk = false
                 n_valid_chunks += 1
             end
+        elseif k == K"ErrorInvalidInterpolationTerminator" || k == K"ErrorBidiFormatting"
+            # Treat these errors as string chunks
+            bump(ps)
         else
             break
         end
@@ -3380,6 +3383,8 @@ function parse_atom(ps::ParseState, check_identifiers=true)
             bump_invisible(ps, K"error", error="unterminated character literal")
         else
             if k == K"Char"
+                bump(ps)
+            elseif is_error(k)
                 bump(ps)
             else
                 # FIXME: This case is actually a tokenization error.

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -19,6 +19,13 @@ end
             Diagnostic(2, 1+sizeof(string(c)), :error, "invisible character $(repr(c))")
     end
     @test diagnostic(":⥻") == Diagnostic(2, 4, :error, "unknown unicode character '⥻'")
+
+    @test diagnostic("\"X \u202a X\"") == Diagnostic(2, 8, :error, "unbalanced bidirectional unicode formatting \"X \\u202a X\"")
+    @test diagnostic("#= \u202a =#") == Diagnostic(1, 9, :error, "unbalanced bidirectional unicode formatting \"#= \\u202a =#\"")
+    @test diagnostic("\"X \u202a \$xx\u202c\"", allow_multiple=true) == [
+        Diagnostic(2, 7, :error, "unbalanced bidirectional unicode formatting \"X \\u202a \"")
+        Diagnostic(11, 13, :error, "unbalanced bidirectional unicode formatting \"\\u202c\"")
+    ]
 end
 
 @testset "parser errors" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1004,3 +1004,24 @@ end
     @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "a \u2212= b") == "(-= a b)"
     @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "a .\u2212= b") == "(.-= a b)"
 end
+
+@testset "Unbalanced bidirectional unicode" begin
+    # https://trojansource.codes
+    @test_throws JuliaSyntax.ParseError parsestmt(GreenNode, """
+    function checkUserAccess(u::User)
+        if u.accessLevel != "user\u202e \u2066# users are not allowed\u2069\u2066"
+            return true
+        end
+        return false
+    end
+    """)
+
+    @test_throws JuliaSyntax.ParseError parsestmt(GreenNode, """
+    function checkUserAccess(u::User)
+        #=\u202e \u2066if (u.isAdmin)\u2069 \u2066 begin admins only =#
+            return true
+        #= end admin only \u202e \u2066end\u2069 \u2066=#
+        return false
+    end
+    """)
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -39,6 +39,14 @@ if VERSION < v"1.6"
     using JuliaSyntax: isnothing, only, peek
 end
 
+function toks(str)
+    ts = [JuliaSyntax.Tokenize.untokenize(t, str)=>kind(t)
+          for t in JuliaSyntax.Tokenize.tokenize(str)]
+    @test ts[end] == (""=>K"EndMarker")
+    pop!(ts)
+    ts
+end
+
 function remove_macro_linenums!(ex)
     if Meta.isexpr(ex, :macrocall)
         ex.args[2] = nothing


### PR DESCRIPTION
Disallow unbalanced Unicode bidirectional formatting directives within strings and comments, to mitigate the "trojan source" vulnerability https://www.trojansource.codes

See also https://github.com/JuliaLang/julia/pull/42918

Fix #242
Closes #270