### PR TITLE
Fix `showerror` to include backtraces

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -14,11 +14,6 @@ function ParseError(stream::ParseStream; kws...)
     ParseError(source, stream.diagnostics)
 end
 
-function Base.showerror(io::IO, err::ParseError, bt; backtrace=false)
-    println(io, "ParseError:")
-    show_diagnostics(io, err.diagnostics, err.source)
-end
-
 function Base.showerror(io::IO, err::ParseError)
     println(io, "ParseError:")
     show_diagnostics(io, err.diagnostics, err.source)

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -119,6 +119,7 @@ end
             # Error @ somefile.jl:1:8
             a -- b -- c
             #      └┘ ── invalid operator"""
+        @test occursin("Stacktrace:\n", sprint(showerror, exc, catch_backtrace()))
         file_url = JuliaSyntax._file_url("somefile.jl")
         @test sprint(showerror, exc, context=:color=>true) == """
             ParseError:


### PR DESCRIPTION
Why this method was there, I don't know!