### PR TITLE
Throw Meta.ParseError from Meta.parse() in Julia 1.10

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -7,11 +7,12 @@
 struct ParseError <: Exception
     source::SourceFile
     diagnostics::Vector{Diagnostic}
+    incomplete_tag::Symbol # Used only for Base Expr(:incomplete) support
 end
 
-function ParseError(stream::ParseStream; kws...)
+function ParseError(stream::ParseStream; incomplete_tag=:none, kws...)
     source = SourceFile(sourcetext(stream); kws...)
-    ParseError(source, stream.diagnostics)
+    ParseError(source, stream.diagnostics, incomplete_tag)
 end
 
 function Base.showerror(io::IO, err::ParseError)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,4 +2,9 @@
 let filename = joinpath(@__DIR__, "literal_parsing.jl")
     text = read(filename, String)
     parseall(Expr, text)
+    if _has_v1_6_hooks
+        enable_in_core!()
+        Meta.parse("1 + 2")
+        enable_in_core!(false)
+    end
 end


### PR DESCRIPTION
New hooks added in https://github.com/JuliaLang/julia/pull/46372 allow us to

* Add `JuliaSyntax.ParseError` as the new detail field of `Meta.ParseError`, preserving the detailed error information and ability to overload `showerror`, without disrupting `Base` too much.
* Return `Expr(:incomplete, Meta.ParseError(...))` for incomplete expressions while having `incomplete_tag` still work.