### PR TITLE
Minor tweaks to remove method ambiguities and argument ambiguities

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -20,9 +20,6 @@ function Base.showerror(io::IO, err::ParseError)
     show_diagnostics(io, err.diagnostics, err.source)
 end
 
-Base.display_error(io::IO, err::ParseError, bt) = Base.showerror(io, err, bt)
-
-
 """
     parse!(stream::ParseStream; rule=:all)
 

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -7,6 +7,14 @@ mutable struct TreeNode{NodeData}   # ? prevent others from using this with Node
     parent::Union{Nothing,TreeNode{NodeData}}
     children::Union{Nothing,Vector{TreeNode{NodeData}}}
     data::Union{Nothing,NodeData}
+
+    # Use this constructor rather than the automatically generated one to pass
+    # Test.detect_unbound_args() test in Base.
+    function TreeNode{NodeData}(parent::Union{Nothing,TreeNode{NodeData}},
+                                children::Union{Nothing,Vector{TreeNode{NodeData}}},
+                                data::Union{Nothing,NodeData}) where {NodeData}
+        new{NodeData}(parent, children, data)
+    end
 end
 
 # Implement "pass-through" semantics for field access: access fields of `data`

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -1,6 +1,6 @@
 module Tokenize
 
-export tokenize, untokenize, Tokens
+export tokenize, untokenize
 
 using ..JuliaSyntax: JuliaSyntax, Kind, @K_str, @KSet_str
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -15,3 +15,10 @@
     @test ps("XX", fgcolor=:red, bgcolor=:green, href="https://www.example.com") ==
         "\e]8;;https://www.example.com\e\\\e[31m\e[42mXX\e[0;0m\e]8;;\e\\"
 end
+
+@testset "ambiguities" begin
+    if VERSION >= v"1.8"
+        @test detect_ambiguities(JuliaSyntax) == []
+        @test detect_unbound_args(JuliaSyntax) == []
+    end
+end


### PR DESCRIPTION
These were harmless enough, but should satisfy the tests in Base.

Also remove a display_error() overload because (a) it's not designed to be overridden, and (b) this override doesn't really have the intended effect anyway in the latest version where the REPL uses exception stacks more extensively.