### PR TITLE
Fix for short form function line numbers

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -207,9 +207,13 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
         headsym = :if
     elseif k == K"=" && !is_decorated(head)
         a2 = args[2]
-        if is_eventually_call(args[1]) && !@isexpr(a2, :block)
-            # Add block for short form function locations
-            args[2] = Expr(:block, loc, a2)
+        if is_eventually_call(args[1])
+            if @isexpr(a2, :block)
+                pushfirst!(a2.args, loc)
+            else
+                # Add block for short form function locations
+                args[2] = Expr(:block, loc, a2)
+            end
         end
     elseif k == K"macrocall"
         _reorder_parameters!(args, 2)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -169,6 +169,25 @@
                       LineNumberNode(1),
                       :xs))
 
+        @test parsestmt("f() =\n(a;b)") ==
+            Expr(:(=),
+                 Expr(:call, :f),
+                 Expr(:block,
+                      LineNumberNode(1),
+                      :a,
+                      LineNumberNode(2),
+                      :b))
+
+        @test parsestmt("f() =\nbegin\na\nb\nend") ==
+            Expr(:(=),
+                 Expr(:call, :f),
+                 Expr(:block,
+                      LineNumberNode(1),
+                      LineNumberNode(3),
+                      :a,
+                      LineNumberNode(4),
+                      :b))
+
         @test parsestmt("let f(x) =\ng(x)=1\nend") ==
             Expr(:let,
                  Expr(:(=),


### PR DESCRIPTION
Ensure we add short form function line numbers to the `Expr` when there's a block on the right hand side.