### PR TITLE
Add trailing line numbers to loops in Expr conversion

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -195,6 +195,7 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
     end
 
     loc = source_location(LineNumberNode, source, first(srcrange))
+    endloc = source_location(LineNumberNode, source, last(srcrange))
 
     _fixup_Expr_children!(head, loc, args)
 
@@ -270,6 +271,12 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
         if @isexpr(a1, :cartesian_iterator)
             args[1] = Expr(:block, a1.args...)
         end
+        # Add extra line number node for the `end` of the block. This may seem
+        # useless but it affects code coverage.
+        push!(args[2].args, endloc)
+    elseif k == K"while"
+        # Line number node for the `end` of the block as in `for` loops.
+        push!(args[2].args, endloc)
     elseif k in KSet"tuple vect braces"
         # Move parameters blocks to args[1]
         _reorder_parameters!(args, 1)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -158,6 +158,43 @@
                      )
                 )
         end
+
+        @testset "Loops" begin
+            @test parsestmt("for x=xs\n\nend") ==
+                Expr(:for,
+                     Expr(:(=), :x, :xs),
+                     Expr(:block,
+                          LineNumberNode(1),
+                          LineNumberNode(3)
+                     )
+                )
+            @test parsestmt("for x=xs\ny\nend") ==
+                Expr(:for,
+                     Expr(:(=), :x, :xs),
+                     Expr(:block,
+                          LineNumberNode(2),
+                          :y,
+                          LineNumberNode(3)
+                     )
+                )
+            @test parsestmt("while cond\n\nend") ==
+                Expr(:while,
+                     :cond,
+                     Expr(:block,
+                          LineNumberNode(1),
+                          LineNumberNode(3)
+                     )
+                )
+            @test parsestmt("while cond\ny\nend") ==
+                Expr(:while,
+                     :cond,
+                     Expr(:block,
+                          LineNumberNode(2),
+                          :y,
+                          LineNumberNode(3)
+                     )
+                )
+        end
     end
 
     @testset "Short form function line numbers" begin
@@ -213,7 +250,8 @@
                  Expr(:(=), :i, :is),
                  Expr(:block,
                      LineNumberNode(1),
-                     :body
+                     :body,
+                     LineNumberNode(1)
                  )
             )
         @test parsestmt("for i=is, j=js\nbody\nend") ==
@@ -224,7 +262,8 @@
                  ),
                  Expr(:block,
                      LineNumberNode(2),
-                     :body
+                     :body,
+                     LineNumberNode(3),
                  )
             )
     end


### PR DESCRIPTION
These trailing line numbers are used to attribute coverage to the `end` of the loop for parts of the loop header which run there after lowering.

At least, I think that's what's going on with the fact that coverage changes when using JuliaSyntax in Base.