### PR TITLE
Improvements to General registry test tools

### DIFF
--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -211,7 +211,7 @@ function find_source_in_path(basedir)
     src_list = String[]
     for (root, dirs, files) in walkdir(basedir)
         append!(src_list, (joinpath(root, f) for f in files
-                           if endswith(f, ".jl") && isfile(joinpath(root,f))))
+                           if endswith(f, ".jl") && (p = joinpath(root,f); !islink(p) && isfile(p))))
     end
     src_list
 end

--- a/tools/untar_packages.jl
+++ b/tools/untar_packages.jl
@@ -2,16 +2,37 @@ using Serialization
 using JuliaSyntax
 
 pkgspath = joinpath(@__DIR__, "pkgs")
+tarspath = joinpath(@__DIR__, "pkg_tars")
 
-for tars in Iterators.partition(readdir(pkgspath), 50)
-    @sync for tar in tars
-        endswith(tar, ".tgz") || continue
+mkpath(pkgspath)
+mkpath(tarspath)
+
+tar_info = [(m = match(r"(.*)_(\d+\.\d+\.\d+.*)\.tgz$", f); (f, m[1], VersionNumber(m[2])))
+            for f in readdir(tarspath) if endswith(f, ".tgz")]
+
+tar_maxver = Dict{String,VersionNumber}()
+for (_,name,ver) in tar_info
+    v = get(tar_maxver, name, v"0.0.0")
+    if v < ver
+        tar_maxver[name] = ver
+    end
+end
+
+@info "# Untarring packages"
+
+for tinfos in Iterators.partition(tar_info, 50)
+    @sync for (tarname, pkgname, pkgver) in tinfos
         @async begin
-            dir = joinpath(@__DIR__, "pkgs", replace(tar, r"\.tgz$" => ""))
-            if !isdir(dir) || !isdir(joinpath(dir, "src"))
+            dir = joinpath(pkgspath, "$(pkgname)_$(pkgver)")
+            if pkgver != tar_maxver[pkgname]
+                if isdir(dir)
+                    # Clean up old packages
+                    rm(dir; recursive=true, force=true)
+                end
+            elseif !isdir(dir) || !isdir(joinpath(dir, "src"))
                 rm(dir; recursive=true, force=true)
                 mkpath(dir)
-                tar_path = joinpath(@__DIR__, "pkgs", tar)
+                tar_path = joinpath(tarspath, tarname)
                 try
                     run(`tar -xf $tar_path -C $dir`)
                 catch err
@@ -22,20 +43,21 @@ for tars in Iterators.partition(readdir(pkgspath), 50)
     end
 end
 
-@info "Parsing files with reference parser"
+@info "# Parsing files with reference parser"
 
-let i = 0
+let i = 0, tot_files = 0
     for (r, _, files) in walkdir(pkgspath)
         for f in files
+            tot_files += 1
             endswith(f, ".jl") || continue
             fpath = joinpath(r, f)
             outpath = joinpath(r, f*".Expr")
-            if isfile(fpath)
+            if !islink(fpath) && isfile(fpath) && !isfile(outpath)
                 code = read(fpath, String)
                 fl_ex = JuliaSyntax.fl_parseall(code, filename=fpath)
                 i += 1
                 if i % 100 == 0
-                    @info "$i files parsed"
+                    @info "$i/$tot_files files parsed"
                 end
                 open(outpath, "w") do io
                     serialize(io, fl_ex)


### PR DESCRIPTION
* Use a separate directory for tar files vs unpacked packages
* Avoid crashing with overlong corrupt symlinks in packages
* When updating the package cache, delete older versions of the same packages.