### PR TITLE
Normalize `global (x,y)` syntax during `Expr` conversion

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -411,10 +411,16 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
             end
         end
     elseif k == K"local" || k === K"global"
-        if length(args) == 1 && (a1 = args[1]; @isexpr(a1, :const))
-            # Normalize `local const` to `const local`
-            args[1] = Expr(headsym, (a1::Expr).args...)
-            headsym = :const
+        if length(args) == 1
+            a1 = args[1]
+            if @isexpr(a1, :const)
+                # Normalize `local const` to `const local`
+                args[1] = Expr(headsym, (a1::Expr).args...)
+                headsym = :const
+            elseif @isexpr(a1, :tuple)
+                # Normalize `global (x, y)` to `global x, y`
+                args = a1.args
+            end
         end
     elseif k == K"return" && isempty(args)
         push!(args, nothing)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -670,6 +670,10 @@
         @test parsestmt("const x = 1") == Expr(:const, Expr(:(=), :x, 1))
         @test parsestmt("global x ~ 1") == Expr(:global, Expr(:call, :~, :x, 1))
         @test parsestmt("global x += 1") == Expr(:global, Expr(:+=, :x, 1))
+
+        # Parsing of global/local with 
+        @test parsestmt("global (x,y)") == Expr(:global, :x, :y)
+        @test parsestmt("local (x,y)") == Expr(:local, :x, :y)
     end
 
     @testset "tuples" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -133,10 +133,7 @@ function exprs_roughly_equal(fl_ex, ex)
         return false
     end
     h = ex.head
-    if (h == :global || h == :local) && length(args) == 1 && Meta.isexpr(args[1], :tuple)
-        # Allow invalid syntax like `global (x, y)`
-        args = args[1].args
-    elseif h == :function && Meta.isexpr(fl_args[1], :block)
+    if h == :function && Meta.isexpr(fl_args[1], :block)
         blockargs = filter(x->!(x isa LineNumberNode), fl_args[1].args)
         posargs = blockargs[1:max(0, length(blockargs))]
         kwargs = blockargs[2:end]

--- a/test/test_utils_tests.jl
+++ b/test/test_utils_tests.jl
@@ -1,11 +1,6 @@
 # Tests for the test_utils go here to allow the utils to be included on their
 # own without invoking the tests.
 @testset "Reference parser bugs" begin
-    # `global (x,y)`
-    @test exprs_roughly_equal(Expr(:global, :x, :y),
-                              Expr(:global, Expr(:tuple, :x, :y)))
-    @test exprs_roughly_equal(Expr(:local, :x, :y),
-                              Expr(:local, Expr(:tuple, :x, :y)))
     # `0x1.8p0f`
     @test exprs_roughly_equal(1.5,
                               Expr(:call, :*, 1.5, :f))


### PR DESCRIPTION
The reference parser accepts this syntax and normalizes it eagerly. So we should do the same rather than making it part of fuzzy Expr comparison later.