### PR TITLE
Allow parsing of custom string types in core parser hook

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -143,6 +143,10 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
             # The C entry points will pass us this form.
             (ptr,len) = code
             code = String(unsafe_wrap(Array, ptr, len))
+        elseif !(code isa String || code isa SubString || code isa Vector{UInt8})
+            # For non-Base string types, convert to UTF-8 encoding, using an
+            # invokelatest to avoid world age issues.
+            code = Base.invokelatest(String, code)
         end
         if !isnothing(_debug_log[])
             print(_debug_log[], """

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -76,6 +76,19 @@
             @test_throws JuliaSyntax.ParseError Meta.parse("[x)")
         end
 
+        # Check custom string types defined in a world age later than
+        # enable_in_core!() can be passed to Meta.parse()
+        mystr = @eval begin
+            struct MyString <: AbstractString
+                x::String
+            end
+            Base.String(s::MyString) = s.x
+            Base.ncodeunits(s::MyString) = ncodeunits(s.x)
+
+            MyString("hi")
+        end
+        @test Meta.parse(mystr) == :hi
+
         JuliaSyntax.enable_in_core!(false)
     end
 


### PR DESCRIPTION
The simplest method of doing this is to convert to String, so that's what we do here, using invokelatest.