### PR TITLE
Syntax experiment: String format syntax eg `"$(x, digits=2)"`

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -887,6 +887,7 @@ const _kind_names =
         "inert"          # QuoteNode; not quasiquote
         "juxtapose"      # Numeric juxtaposition like 2x
         "string"         # A string interior node (possibly containing interpolations)
+        "format"         # String formatting specification
         "cmdstring"      # A cmd string node (containing delimiters plus string)
         "char"           # A char string node (containing delims + char data)
         "macrocall"

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3182,14 +3182,16 @@ function parse_string(ps::ParseState, raw::Bool)
                 m = position(ps)
                 bump(ps, TRIVIA_FLAG)
                 opts = parse_brackets(ps, K")") do had_commas, had_splat, num_semis, num_subexprs
-                    return (needs_parameters=false,
+                    return (needs_parameters=true,
                             simple_interp=!had_commas && num_semis == 0 && num_subexprs == 1)
                 end
                 if !opts.simple_interp || peek_behind(ps, skip_parens=false).kind == K"generator"
                     # "$(x,y)" ==> (string (parens (error x y)))
-                    emit(ps, m, K"error", error="invalid interpolation syntax")
+                    emit(ps, m, K"format")
+                    min_supported_version(v"1.10", ps, m, "string formatting syntax")
+                else
+                    emit(ps, m, K"parens")
                 end
-                emit(ps, m, K"parens")
             elseif k == K"var"
                 # var identifiers disabled in strings
                 # "$var"  ==>  (string var)


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/18703

```julia
julia> JuliaSyntax.parsestmt(SyntaxNode, "\"prefix \$(1.0, digits=2) suffix\"")
line:col│ tree                                   │ file_name
   1:1  │[string]
   1:2  │  "prefix "
   1:10 │  [format]
   1:11 │    1.0
   1:16 │    [=]
   1:16 │      digits
   1:23 │      2
   1:25 │  " suffix"


julia> JuliaSyntax.parsestmt(Expr, "\"prefix \$(1.0, digits=2) suffix\"")
:("prefix $($(Expr(:format, 1.0, :(digits = 2)))) suffix")
```

CC @simonbyrne 