### PR TITLE
Parse `function (:*=(f))() end` syntax compatibly

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -568,6 +568,7 @@ tests = [
         "function (::g(x))() end" => "(function (call (parens (::-pre (call g x)))) (block))"
         "function (f::T{g(i)})() end" => "(function (call (parens (::-i f (curly T (call g i))))) (block))"
         "function (::T)() end" =>  "(function (call (parens (::-pre T))) (block))"
+        "function (:*=(f))() end" => "(function (call (parens (call (quote-: *=) f))) (block))"
         "function begin() end" =>  "(function (call (error begin)) (block))"
         "function f() end"     =>  "(function (call f) (block))"
         "function type() end"  =>  "(function (call type) (block))"

--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -8,8 +8,8 @@ using JuliaSyntax, Logging, TerminalLoggers, ProgressLogging, Serialization
 include("../test/test_utils.jl")
 include("../test/fuzz_test.jl")
 
-srcpath = isempty(ARGS) ? joinpath(@__DIR__, "pkgs") : ARGS[1]
-source_paths = find_source_in_path(srcpath)
+srcpaths = isempty(ARGS) ? [joinpath(@__DIR__, "pkgs")] : abspath.(ARGS)
+source_paths = vcat(find_source_in_path.(srcpaths)...)
 
 file_count = length(source_paths)
 


### PR DESCRIPTION
Slightly modify the anonymous function arg list disambiguation rules so that the function signature in this syntax parses as

    (call (call (quote *=) f))

The package NiLang uses this, so we'd like to keep it working.

Fixes the final niggling case in #134.

See also https://github.com/GiggleLiu/NiLang.jl/issues/83