### PR TITLE
Fixes for `SourceFile` byte offsets

### DIFF
--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -91,11 +91,6 @@ function show_diagnostics(io::IO, diagnostics::AbstractVector{Diagnostic}, text:
     show_diagnostics(io, diagnostics, SourceFile(text))
 end
 
-function emit_diagnostic(diagnostics::AbstractVector{Diagnostic},
-                         byterange::AbstractUnitRange; kws...)
-    push!(diagnostics, Diagnostic(first(byterange), last(byterange); kws...))
-end
-
 function any_error(diagnostics::AbstractVector{Diagnostic})
     any(is_error(d) for d in diagnostics)
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -457,8 +457,7 @@ end
 
 function build_tree(::Type{Expr}, stream::ParseStream;
                     filename=nothing, first_line=1, kws...)
-    source = SourceFile(sourcetext(stream), first_index=first_byte(stream),
-                        filename=filename, first_line=first_line)
+    source = SourceFile(stream, filename=filename, first_line=first_line)
     txtbuf = unsafe_textbuf(stream)
     args = Any[]
     childranges = UnitRange{Int}[]

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -459,7 +459,7 @@ function build_tree(::Type{Expr}, stream::ParseStream;
                     filename=nothing, first_line=1, kws...)
     source = SourceFile(sourcetext(stream), first_index=first_byte(stream),
                         filename=filename, first_line=first_line)
-    txtbuf = textbuf(stream)
+    txtbuf = unsafe_textbuf(stream)
     args = Any[]
     childranges = UnitRange{Int}[]
     childheads = SyntaxHead[]

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -901,11 +901,16 @@ function emit_diagnostic(stream::ParseStream, mark::ParseStreamPosition,
     emit_diagnostic(stream, fbyte:lbyte; kws...)
 end
 
+function emit_diagnostic(diagnostics::AbstractVector{Diagnostic},
+                         byterange::AbstractUnitRange; kws...)
+    push!(diagnostics, Diagnostic(first(byterange), last(byterange); kws...))
+end
+
 #-------------------------------------------------------------------------------
 # ParseStream Post-processing
 
 function validate_tokens(stream::ParseStream)
-    txtbuf = textbuf(stream)
+    txtbuf = unsafe_textbuf(stream)
     toks = stream.tokens
     charbuf = IOBuffer()
     for i = 2:length(toks)
@@ -1104,11 +1109,14 @@ function sourcetext(stream::ParseStream; steal_textbuf=false)
 end
 
 """
-    textbuf(stream)
+    unsafe_textbuf(stream)
 
 Return the `Vector{UInt8}` text buffer being parsed by this `ParseStream`.
+
+!!! warning
+    The caller must hold a reference to `stream` while using textbuf
 """
-textbuf(stream) = stream.textbuf
+unsafe_textbuf(stream) = stream.textbuf
 
 first_byte(stream::ParseStream) = first(stream.tokens).next_byte # Use sentinel token
 last_byte(stream::ParseStream) = _next_byte(stream)-1

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -1108,6 +1108,10 @@ function sourcetext(stream::ParseStream; steal_textbuf=false)
     SubString(str, first_byte(stream), thisind(str, last_byte(stream)))
 end
 
+function SourceFile(stream::ParseStream; kws...)
+    return SourceFile(sourcetext(stream); first_index=first_byte(stream), kws...)
+end
+
 """
     unsafe_textbuf(stream)
 

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -11,7 +11,7 @@ struct ParseError <: Exception
 end
 
 function ParseError(stream::ParseStream; incomplete_tag=:none, kws...)
-    source = SourceFile(sourcetext(stream); kws...)
+    source = SourceFile(stream; kws...)
     ParseError(source, stream.diagnostics, incomplete_tag)
 end
 

--- a/src/source_files.jl
+++ b/src/source_files.jl
@@ -76,7 +76,8 @@ function source_line_range(source::SourceFile, byte_index;
     lineidx = _source_line_index(source, byte_index)
     fbyte = source.line_starts[max(lineidx-context_lines_before, 1)]
     lbyte = source.line_starts[min(lineidx+1+context_lines_after, end)] - 1
-    fbyte,lbyte
+    return (fbyte + source.byte_offset,
+            lbyte + source.byte_offset)
 end
 
 function source_location(::Type{LineNumberNode}, source::SourceFile, byte_index)
@@ -120,7 +121,7 @@ function Base.getindex(source::SourceFile, i::Int)
 end
 
 function Base.thisind(source::SourceFile, i::Int)
-    thisind(source.code, i - source.byte_offset)
+    thisind(source.code, i - source.byte_offset) + source.byte_offset
 end
 
 Base.firstindex(source::SourceFile) = firstindex(source.code) + source.byte_offset

--- a/test/source_files.jl
+++ b/test/source_files.jl
@@ -28,8 +28,14 @@
     end
 
     # byte offset
-    @test source_location(SourceFile("a\nbb\nccc\ndddd", first_index=10), 13) == (2,2)
-    @test source_line(SourceFile("a\nbb\nccc\ndddd", first_index=10), 15) == 3
+    sf = SourceFile("a\nbb\nccc\ndddd", first_index=10)
+    @test source_location(sf, 13) == (2,2)
+    @test source_line(sf, 15) == 3
+    @test source_line_range(sf, 10) == (10,11)
+    @test source_line_range(sf, 11) == (10,11)
+    @test source_line_range(sf, 12) == (12,14)
+    @test source_line_range(sf, 14) == (12,14)
+    @test source_line_range(sf, 15) == (15,18)
 
     # source_line convenience function
     @test source_line(SourceFile("a\nb\n"), 2) == 1
@@ -51,6 +57,11 @@ end
     @test sf[10] == 'a'
     @test sf[10:11] == "ab"
     @test view(sf, 10:11) == "ab"
+
+    @test thisind(SourceFile("xαx", first_index=10), 10) == 10
+    @test thisind(SourceFile("xαx", first_index=10), 11) == 11
+    @test thisind(SourceFile("xαx", first_index=10), 12) == 11
+    @test thisind(SourceFile("xαx", first_index=10), 13) == 13
 
     if Base.VERSION >= v"1.4"
         # Protect the `[begin` from being viewed by the parser on older Julia versions

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -49,6 +49,12 @@
     @test length(children(node)) == 2
     node[2] = parsestmt(SyntaxNode, "y")
     @test sourcetext(child(node, 2)) == "y"
+
+    # SyntaxNode with offsets
+    t,_ = parsestmt(SyntaxNode, "begin a end\nbegin b end", 13)
+    @test t.position == 13
+    @test child(t,1).position == 19
+    @test child(t,1).val == :b
 end
 
 @testset "SyntaxNode pretty printing" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -9,6 +9,7 @@ using .JuliaSyntax:
     SourceFile,
     source_location,
     source_line,
+    source_line_range,
     parse!,
     parsestmt,
     parseall,


### PR DESCRIPTION
This fixes a crash formatting error messages when core_parse_hook is used to parse a piece of broken code with a nontrivial byte offset.
    
* `SourceFile` held by `SyntaxNode` preserves the indexing of the original string passed to the `parse*()` functions.
* Fix `source_line_range` and `thisind` accordingly