### PR TITLE
Fix diagnostics covering trailing text

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3561,7 +3561,8 @@ function parse_atom(ps::ParseState, check_identifiers=true)
         msg = leading_kind == K"EndMarker" ?
               "premature end of input" :
               "unexpected `$(untokenize(leading_kind))`"
-        bump_invisible(ps, K"error", error=msg)
+        emit_diagnostic(ps, error=msg)
+        bump_invisible(ps, K"error")
     else
         bump(ps, error="invalid syntax atom")
     end

--- a/src/source_files.jl
+++ b/src/source_files.jl
@@ -219,7 +219,9 @@ function highlight(io::IO, source::SourceFile, range::UnitRange;
         print(io, source[x:p-1])
         _printstyled(io, hitext; bgcolor=color)
         print(io, source[q+1:d])
-        source[thisind(source, d)] == '\n' || print(io, "\n")
+        if d >= firstindex(source) && source[thisind(source, d)] != '\n'
+            print(io, "\n")
+        end
         _print_marker_line(io, source[a:p-1], hitext, true, true, marker_line_color, note, notecolor)
     else
         # x   --------------

--- a/test/source_files.jl
+++ b/test/source_files.jl
@@ -115,6 +115,9 @@ end
     @test sprint(highlight, SourceFile("a\nα"), 1:4) == "┌\na\nα\n┘"
     @test sprint(highlight, SourceFile("a\nb\nα"), 3:3) == "a\nb\n╙\nα"
 
+    # empty files
+    @test sprint(highlight, SourceFile(""), 1:0) == "└"
+
     # Multi-line ranges
     @test sprint(highlight, src, 1:7) == """
         ┌───


### PR DESCRIPTION
Diagnostics may sometimes cover trailing text which wasn't consumed. For example, `parseatom(")")` doesn't consume the errant trailing ')', but the diagnostic refers to this character. In this case, `SourceFile` needs to cover the location of the diagnostic in addition to any text which is consumed.

As part of this, mark `sourcetext(::ParseStream)` as deprecated, in favour of constructing a `SourceFile` to wrap things up more neatly.

Also fix a bug in `highlight()` for empty `SourceFile`s.

Fixes #314 and downstream issue https://github.com/JuliaLang/julia/issues/50245