### PR TITLE
Only show the first parse error

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -17,7 +17,13 @@ end
 
 function Base.showerror(io::IO, err::ParseError)
     println(io, "ParseError:")
-    show_diagnostics(io, err.diagnostics, err.source)
+    # Only show the first parse error for now - later errors are often
+    # misleading due to the way recovery works
+    i = findfirst(is_error, err.diagnostics)
+    if isnothing(i)
+        i = lastindex(err.diagnostics)
+    end
+    show_diagnostics(io, err.diagnostics[1:i], err.source)
 end
 
 """


### PR DESCRIPTION
Parser recovery commonly results in several errors which refer to much the same location in the broken source file and are not useful to the user.

Currently the most useful error is the first one, so this PR trims down error printing to only show that one.

Fixes https://github.com/JuliaLang/julia/issues/50223