### PR TITLE
Add a "not your fault" hint to the fallback to flisp error

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -256,7 +256,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
                     """)
         end
         @error("""JuliaSyntax parser failed — falling back to flisp!
-                  This is probably not your fault, please submit a bug report (https://github.com/JuliaLang/JuliaSyntax.jl/issues)""",
+                  This is not your fault. Please submit a bug report to https://github.com/JuliaLang/JuliaSyntax.jl/issues""",
                exception=(exc,catch_backtrace()),
                offset=offset,
                code=code)

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -255,8 +255,8 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
                     #-#-#-
                     """)
         end
-        @error("JuliaSyntax parser failed — falling back to flisp!\n"*
-               "This is probably not your fault, please submit a bug report (https://github.com/JuliaLang/JuliaSyntax.jl/issues)",
+        @error("""JuliaSyntax parser failed — falling back to flisp!
+                  This is probably not your fault, please submit a bug report (https://github.com/JuliaLang/JuliaSyntax.jl/issues)""",
                exception=(exc,catch_backtrace()),
                offset=offset,
                code=code)

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -255,7 +255,8 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
                     #-#-#-
                     """)
         end
-        @error("JuliaSyntax parser failed — falling back to flisp!",
+        @error("JuliaSyntax parser failed — falling back to flisp!\n"*
+               "This is probably not your fault, please submit a bug report (https://github.com/JuliaLang/JuliaSyntax.jl/issues)",
                exception=(exc,catch_backtrace()),
                offset=offset,
                code=code)


### PR DESCRIPTION
Adds "This is probably not your fault, please submit a bug report (https://github.com/JuliaLang/JuliaSyntax.jl/issues)" to the long message when JuliaSytnax has an internal bug.
```
julia> map([3,4,5])[1] do x
┌ Error: JuliaSyntax parser failed — falling back to flisp!
│ This is probably not your fault, please submit a bug report (https://github.com/JuliaLang/JuliaSyntax.jl/issues)
│   exception =
│    Internal error: length(args) == 3
│    Stacktrace:
│      [1] error(::String, ::String)
│        @ Base ./error.jl:44
│      [2] internal_error(strs::String)
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/utils.jl:23
│      [3] _internal_node_to_Expr(source::Base.JuliaSyntax.SourceFile, srcrange::UnitRange{Int64}, head::Base.JuliaSyntax.SyntaxHead, childranges::Vector{UnitRange{Int64}}, childheads::Vector{Base.JuliaSyntax.SyntaxHead}, args::Vector{Any})
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/expr.jl:399
│      [4] _to_expr(node::Base.JuliaSyntax.SyntaxNode)
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/expr.jl:496
│      [5] _to_expr(node::Base.JuliaSyntax.SyntaxNode) (repeats 2 times)
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/expr.jl:495
│      [6] Expr(node::Base.JuliaSyntax.SyntaxNode)
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/expr.jl:500
│      [7] core_parser_hook(code::String, filename::String, lineno::Int64, offset::Int64, options::Symbol)
│        @ Base.JuliaSyntax ./REPL[6]:72
│      [8] invoke_in_world(::UInt64, ::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
│        @ Base ./essentials.jl:921
│      [9] invoke_in_world(::UInt64, ::Any, ::Any, ::Vararg{Any})
│        @ Base ./essentials.jl:918
│     [10] (::Base.JuliaSyntax.var"#invoke_fixedworld#120"{Base.JuliaSyntax.var"#invoke_fixedworld#117#121"{typeof(Base.JuliaSyntax.core_parser_hook), UInt64}})(::String, ::Vararg{Any}; kws::@Kwargs{})
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/hooks.jl:118
│     [11] (::Base.JuliaSyntax.var"#invoke_fixedworld#120"{Base.JuliaSyntax.var"#invoke_fixedworld#117#121"{typeof(Base.JuliaSyntax.core_parser_hook), UInt64}})(::String, ::Vararg{Any})
│        @ Base.JuliaSyntax /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/hooks.jl:117
│     [12] _parse_string(text::String, filename::String, lineno::Int64, index::Int64, options::Symbol)
│        @ Base.Meta ./meta.jl:200
│     [13] #parseall#6
│        @ Base.Meta ./meta.jl:294 [inlined]
│     [14] parseall
│        @ Base.Meta ./meta.jl:293 [inlined]
│     [15] _parse_input_line_core
│        @ Base ./client.jl:174 [inlined]
│     [16] #parse_input_line#1007
│        @ Base ./client.jl:192 [inlined]
│     [17] parse_input_line
│        @ Base ./client.jl:189 [inlined]
│     [18] (::REPL.var"#93#103"{REPL.LineEditREPL, REPL.REPLHistoryProvider})(x::Any)
│        @ REPL ~/.julia/juliaup/julia-1.10.0-beta2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1077
│     [19] #invokelatest#2
│        @ Base ./essentials.jl:887 [inlined]
│     [20] invokelatest
│        @ Base ./essentials.jl:884 [inlined]
│     [21] (::REPL.var"#do_respond#80"{Bool, Bool, REPL.var"#93#103"{REPL.LineEditREPL, REPL.REPLHistoryProvider}, REPL.LineEditREPL, REPL.LineEdit.Prompt})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
│        @ REPL ~/.julia/juliaup/julia-1.10.0-beta2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:903
│     [22] #invokelatest#2
│        @ Base ./essentials.jl:887 [inlined]
│     [23] invokelatest
│        @ Base ./essentials.jl:884 [inlined]
│     [24] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
│        @ REPL.LineEdit ~/.julia/juliaup/julia-1.10.0-beta2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/LineEdit.jl:2656
│     [25] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
│        @ REPL ~/.julia/juliaup/julia-1.10.0-beta2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1310
│     [26] (::REPL.var"#62#68"{REPL.LineEditREPL, REPL.REPLBackendRef})()
│        @ REPL ~/.julia/juliaup/julia-1.10.0-beta2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:386
│   offset = 0
│   code = "map([3,4,5])[1] do x"
└ @ Base.JuliaSyntax REPL[6]:121
ERROR: syntax: extra token "do" after end of expression
Stacktrace:
 [1] top-level scope
   @ none:1
```

From @topolarity and @vchuravy 's commentary here https://github.com/JuliaLang/JuliaSyntax.jl/issues/340