### PR TITLE
Fix SyntaxNode->Expr conversions of unterminated cmd strings

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -138,10 +138,9 @@ function _string_to_Expr(k, args)
         # If there's a single string remaining after joining, we unwrap
         # to give a string literal.
         #   """\n  a\n  b""" ==>  "a\nb"
-        # k == K"cmdstring" follows this branch
         return only(args2)
     else
-        @check k == K"string"
+        # This only happens when k == K"string" or when an error has occurred. 
         return Expr(:string, args2...)
     end
 end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -349,10 +349,8 @@ end
 # Parser
 #
 # The definitions and top-level comments here were copied to match the
-# structure of Julia's official flisp-based parser.
-#
-# This is to make both codebases mutually understandable and make porting
-# changes simple.
+# structure of Julia's previous flisp-based parser to make both codebases
+# mutually understandable and make porting changes simple.
 #
 # The `parse_*` functions are listed here roughly in order of increasing
 # precedence (lowest to highest binding power). A few helper functions are

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -286,6 +286,13 @@
                  "a\nb")
         @test parsestmt("\"\"\"\n  a\n  \$x\n  b\n  c\"\"\"") ==
             Expr(:string, "a\n", :x, "\nb\nc")
+        # Incomplete cases
+        @test parsestmt("`x", ignore_errors=true) ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@cmd")), LineNumberNode(1),
+                 Expr(:string, "x", Expr(:error)))
+        @test parsestmt("`", ignore_errors=true) ==
+            Expr(:macrocall, GlobalRef(Core, Symbol("@cmd")), LineNumberNode(1),
+                 Expr(:string, Expr(:error)))
     end
 
     @testset "Char conversions" begin


### PR DESCRIPTION
Fixes #353 