### PR TITLE
handle ZWJ and emoji sequences, don't break identifiers within graphemes

### DIFF
--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -44,12 +44,12 @@ end
 end # testset
 
 @testset "tokenize unicode" begin
-    str = "𝘋 =2β"
+    str = "𝘋 =2🏳️‍🌈"
     for s in [str, IOBuffer(str)]
         l = tokenize(s)
         kinds = [K"Identifier", K"Whitespace", K"=",
                  K"Integer", K"Identifier", K"EndMarker"]
-        token_strs = ["𝘋", " ", "=", "2", "β", ""]
+        token_strs = ["𝘋", " ", "=", "2", "🏳️‍🌈", ""]
         for (i, n) in enumerate(l)
             @test kind(n) == kinds[i]
             @test untokenize(n, str)  == token_strs[i]


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/40071 — never break an identifier within a grapheme boundary.  (Identifiers and graphemes may still only start within the pre-existing allowed set of characters.)

This allows to handle identifiers like `🏳️‍🌈` == `🏳️‍[ZWJ]🌈` which contain the [U+200D "Zero-width joiner" (ZWJ)](https://www.fileformat.info/info/unicode/char/200d/index.htm) character, which was not previously allowed since it's in [category Cf (Other, format)](https://www.fileformat.info/info/unicode/category/Cf/list.htm).   However, to prevent incomplete graphemes ending with an invisible ZWJ character, we disallow ZWJ at the *end* of an identifier.