### PR TITLE
Fix Expr conversion of erroneous operator dot call

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -270,11 +270,13 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
             if is_prefix_call(head)
                 headsym = :.
                 args = Any[startsym, Expr(:tuple, args[2:end]...)]
-            elseif startsym isa Symbol
+            else
                 # operator calls
                 headsym = :call
-                args[1] = Symbol(:., startsym)
-            end # else startsym could be an Expr(:error), just propagate it
+                if startsym isa Symbol
+                    args[1] = Symbol(:., startsym)
+                end # else startsym could be an Expr(:error), just propagate it
+            end
         end
         if do_lambda isa Expr
             return Expr(:do, Expr(headsym, args...), do_lambda)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -266,14 +266,15 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
         # Move parameters blocks to args[2]
         _reorder_parameters!(args, 2)
         if headsym === :dotcall
+            startsym = args[1]
             if is_prefix_call(head)
                 headsym = :.
-                args = Any[args[1], Expr(:tuple, args[2:end]...)]
-            else
+                args = Any[startsym, Expr(:tuple, args[2:end]...)]
+            elseif startsym isa Symbol
                 # operator calls
                 headsym = :call
-                args[1] = Symbol(".", args[1])
-            end
+                args[1] = Symbol(:., startsym)
+            end # else startsym could be an Expr(:error), just propagate it
         end
         if do_lambda isa Expr
             return Expr(:do, Expr(headsym, args...), do_lambda)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -266,16 +266,16 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
         # Move parameters blocks to args[2]
         _reorder_parameters!(args, 2)
         if headsym === :dotcall
-            startsym = args[1]
+            funcname = args[1]
             if is_prefix_call(head)
                 headsym = :.
-                args = Any[startsym, Expr(:tuple, args[2:end]...)]
+                args = Any[funcname, Expr(:tuple, args[2:end]...)]
             else
                 # operator calls
                 headsym = :call
-                if startsym isa Symbol
-                    args[1] = Symbol(:., startsym)
-                end # else startsym could be an Expr(:error), just propagate it
+                if funcname isa Symbol
+                    args[1] = Symbol(:., funcname)
+                end # else funcname could be an Expr(:error), just propagate it
             end
         end
         if do_lambda isa Expr

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -466,7 +466,7 @@
 
         # Issue #341
         @test parsestmt("f(./x)", ignore_errors=true) == Expr(:call, :f,
-                                                            Expr(:dotcall,
+                                                            Expr(:call,
                                                                 Expr(:error, Expr(:., :/)),
                                                                 :x))
     end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -463,6 +463,12 @@
         @test parsestmt("f(.+)")   == Expr(:call, :f, Expr(:., :+))
         @test parsestmt("(a, .+)") == Expr(:tuple, :a, Expr(:., :+))
         @test parsestmt("A.:.+")   == Expr(:., :A, QuoteNode(Symbol(".+")))
+
+        # Issue #341
+        @test parsestmt("f(./x)", ignore_errors=true) == Expr(:call, :f,
+                                                            Expr(:dotcall,
+                                                                Expr(:error, Expr(:., :/)),
+                                                                :x))
     end
 
     @testset "let" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -465,10 +465,7 @@
         @test parsestmt("A.:.+")   == Expr(:., :A, QuoteNode(Symbol(".+")))
 
         # Issue #341
-        @test parsestmt("f(./x)", ignore_errors=true) == Expr(:call, :f,
-                                                            Expr(:call,
-                                                                Expr(:error, Expr(:., :/)),
-                                                                :x))
+        @test parsestmt("./x", ignore_errors=true) == Expr(:call, Expr(:error, Expr(:., :/)), :x)
     end
 
     @testset "let" begin


### PR DESCRIPTION
Fix #341

The root issue was the unconditional conversion of an `Expr(:dotcall, foo, ...)` to `Expr(:call, Symbol(:., foo), ...)` when `foo` was not an `Expr(:., ...)`. That case corresponds to dotted operators (where `foo` is the symbol of the operator), but it can actually also occur when there is a parsing error, such as misplacing a non-unitary dotted operator like in the MWE.

I'm not completely sure what `Expr` should be yielded here, I went for `Expr(:dotcall, Expr(:error, Expr(:., foo), ...)` because it required minimal change, but let me know if it should be something else!