### PR TITLE
Generalize fuzz testing tools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,8 @@ julia = "1.0"
 [deps]
 
 [extras]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Logging"]

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -231,12 +231,11 @@ end
         \e[90m# └┘ ── \e[0;0m\e[91minvalid operator\e[0;0m"""
 
     if Sys.isunix()
-        mktempdir() do tempdirname
-            cd(tempdirname) do
-                rm(tempdirname)
-                # Test _file_url doesn't fail with nonexistant directories
-                @test isnothing(JuliaSyntax._file_url(joinpath("__nonexistant__", "test.jl")))
-            end
+        tempdirname = mktempdir()
+        cd(tempdirname) do
+            rm(tempdirname)
+            # Test _file_url doesn't fail with nonexistant directories
+            @test isnothing(JuliaSyntax._file_url(joinpath("__nonexistant__", "test.jl")))
         end
     end
 end


### PR DESCRIPTION
This rearrangement allows us to fuzz test the hooks (which use the low level parser API) as well as the high level parser API.

We've had various cases of bugs in the hook system which aren't reflected in the high level parser API. Fuzz testing more of the system is one way to catch some of these bugs.