### PR TITLE
Fix crash with empty macro name when parsing `"@("`

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2316,6 +2316,9 @@ function fix_macro_name_kind!(ps::ParseState, macro_name_position, name_kind=not
     elseif k == K"parens"
         # @(A) x  ==>  (macrocall (parens @A) x)
         macro_name_position = first_child_position(ps, macro_name_position)
+        if macro_name_position == NO_POSITION
+            return
+        end
         k = peek_behind(ps, macro_name_position).kind
     elseif k == K"error"
         # Error already reported in parse_macro_name

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -999,6 +999,8 @@ parsestmt_test_specs = [
     # shouldn't crash
     "@(x y)" => "(macrocall (parens @x (error-t y)))"
     "|(&\nfunction" => "(call | (& (function (error (error)) (block (error)) (error-t))) (error-t))"
+    "@(" => "(macrocall (parens (error-t)))"
+    "x = @(" => "(= x (macrocall (parens (error-t))))"
 
     # The following is currently broken but at least the parser shouldn't
     # crash.


### PR DESCRIPTION
Fix part of #380