### PR TITLE
Fix error in hooks when parsing incomplete `x.`

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -127,6 +127,8 @@ function _has_nested_error(ex)
         else
             return any(_has_nested_error(e) for e in ex.args)
         end
+    elseif ex isa QuoteNode
+        return _has_nested_error(ex.value)
     else
         return false
     end

--- a/test/fuzz_test.jl
+++ b/test/fuzz_test.jl
@@ -969,6 +969,10 @@ function product_token_fuzz(tokens, N)
     (join(ts) for ts in Iterators.product([tokens for _ in 1:N]...))
 end
 
+function random_token_fuzz(tokens, ntokens, ntries)
+    (join(rand(tokens, ntokens)) for _ in 1:ntries)
+end
+
 """
 Fuzz test parser against randomly generated binary strings
 """

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -66,6 +66,10 @@ end
             LineNumberNode(4, "somefile"),
         ]
         @test Meta.isexpr(ex.args[6], :error)
+
+        ex = JuliaSyntax.core_parser_hook("x.", "somefile", 0, 0, :all)[1]
+        @test ex.head == :toplevel
+        @test ex.args[2].head == :incomplete
     end
 
     @testset "enable_in_core!" begin


### PR DESCRIPTION
Fixes part of  #380

(This may have crept in as part of #325?)