### PR TITLE
Fix crash when parsing malformed `function(where`

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3475,6 +3475,9 @@ function parse_atom(ps::ParseState, check_identifiers=true)
         # xx  ==>  xx
         # x₁  ==>  x₁
         bump(ps)
+    elseif is_word_operator(leading_kind)
+        # where=1 ==> (= where 1)
+        bump(ps, remap_kind=K"Identifier")
     elseif is_operator(leading_kind)
         # +     ==>  +
         # .+    ==>  (. +)

--- a/test/fuzz_test.jl
+++ b/test/fuzz_test.jl
@@ -905,7 +905,11 @@ function try_hook_failure(str)
     try
         test_logger = Test.TestLogger()
         Logging.with_logger(test_logger) do
-            Meta_parseall(str)
+            try
+                Meta_parseall(str)
+            catch exc
+                exc isa Meta.ParseError || exc isa JuliaSyntax.ParseError || rethrow()
+            end
         end
         if !isempty(test_logger.logs)
             return str

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1004,6 +1004,7 @@ parsestmt_test_specs = [
     "|(&\nfunction" => "(call | (& (function (error (error)) (block (error)) (error-t))) (error-t))"
     "@(" => "(macrocall (parens (error-t)))"
     "x = @(" => "(= x (macrocall (parens (error-t))))"
+    "function(where" => "(function (tuple-p where (error-t)) (block (error)) (error-t))"
     # Contextual keyword pairs must not be separated by newlines even within parens
     "(abstract\ntype X end)" => "(wrapper (parens abstract (error-t type X)) (error-t end ✘))"
     "(mutable\nstruct X end)" => "(wrapper (parens mutable (error-t struct X)) (error-t end ✘))"


### PR DESCRIPTION
When word operators are parsed as atoms (ie, identifiers), the kind should be remapped as such. This fixes a crash when parsing `function(where` because `was_eventually_call` assumes that a kind of `K"where"` implies an internal node.

Part of #380 