### PR TITLE
Improve error message for missing closing tokens

### DIFF
--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -64,14 +64,17 @@ end
         Diagnostic(16, 16, :error, "missing condition in `elseif`")
 
     @test diagnostic("f(x::V) where {V) = x", allow_multiple=true) == [
-        Diagnostic(17, 16, :error, "Expected `}`")
+        Diagnostic(17, 16, :error, "Expected `}` or `,`")
         Diagnostic(17, 21, :error, "extra tokens after end of expression")
     ]
     @test diagnostic("[1)", allow_multiple=true) == [
-        Diagnostic(3, 2, :error, "Expected `]`")
+        Diagnostic(3, 2, :error, "Expected `]` or `,`")
         Diagnostic(3, 3, :error, "extra tokens after end of expression")
     ]
-
+    @test diagnostic("f(x, y #=hi=#\ng(z)") == Diagnostic(7, 6, :error, "Expected `)` or `,`")
+    @test diagnostic("(x, y \nz") == Diagnostic(6, 5, :error, "Expected `)` or `,`")
+    @test diagnostic("function f(x, y \nz end") == Diagnostic(16, 15, :error, "Expected `)` or `,`")
+ 
     @test diagnostic("sin. (1)") ==
         Diagnostic(5, 5, :error, "whitespace is not allowed here")
     @test diagnostic("x [i]") ==

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -52,7 +52,7 @@ end
         @test err.source.first_line == 1
         @test err.diagnostics[1].first_byte == 6
         @test err.diagnostics[1].last_byte == 5
-        @test err.diagnostics[1].message == "Expected `}`"
+        @test err.diagnostics[1].message == "Expected `}` or `,`"
     end
 
     @testset "toplevel errors" begin


### PR DESCRIPTION
When a missing closing token like `)`, `]` or `}` is encountered we want the "Expected `)`" error to point to a location one past the last valid token, not to the trailing error tokens.

For example from #349 here's a poor error message from the existing code:

    ERROR: ParseError:
    # Error @ REPL[53]:15:5
        ylims!(p, (0, last(ylims(p)))
        xlabel!(p, "Contig length cutoff (kbp)")
    #   └─────────────────────────────────────┘ ── Expected `)`

After this change, the error location instead points to the end of the last valid line:

    ERROR: ParseError:
    # Error @ REPL[53]:15:5
        ylims!(p, (0, last(ylims(p)))
    #                                └── Expected `)`


Fix #349, fix #313