### PR TITLE
tokenize.jl:  don‘t hardcode unicode ops range

### DIFF
--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -171,7 +171,7 @@ function optakessuffix(k)
         k == K"!"   ||
         k == K".'"  ||
         k == K"->"  ||
-        K"¬" <= k <= K"∜"
+        K"BEGIN_UNICODE_OPS" <= k <= K"END_UNICODE_OPS"
     )
 end
 


### PR DESCRIPTION
There are very nice `(BEGIN|END)_UNICODE_OPS` kinds; they should be used!