### PR TITLE
Remove unused `is_error` import in Tokenize module

### DIFF
--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -5,7 +5,7 @@ export tokenize, untokenize
 using ..JuliaSyntax: JuliaSyntax, Kind, @K_str, @KSet_str
 
 import ..JuliaSyntax: kind,
-    is_literal, is_error, is_contextual_keyword, is_word_operator
+    is_literal, is_contextual_keyword, is_word_operator
 
 #-------------------------------------------------------------------------------
 # Character-based predicates for tokenization


### PR DESCRIPTION
I was testing [ExplicitImports.jl](https://github.com/ericphanson/ExplicitImports.jl) and noticed this unnecessary import:
````julia
julia> using JuliaSyntax, ExplicitImports

julia> print_explicit_imports(JuliaSyntax)
Module JuliaSyntax is not relying on any implicit imports.
Module JuliaSyntax.Tokenize is not relying on any implicit imports.

Additionally JuliaSyntax.Tokenize has stale explicit imports for these unused names:
JuliaSyntax
is_error
````

I left the `JuliaSyntax` one since I figured it could be annoying if you are working in that module and the name is unexpectedly unavailable. I feel that removing the `is_error` one improves clarity though, as it makes it easier to see that Tokenize does not add a method for `is_error` (or even use it).