### PR TITLE
unhandled kwargs throw errors

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -140,7 +140,7 @@ function _string_to_Expr(k, args)
         #   """\n  a\n  b""" ==>  "a\nb"
         return only(args2)
     else
-        # This only happens when k == K"string" or when an error has occurred. 
+        # This only happens when k == K"string" or when an error has occurred.
         return Expr(:string, args2...)
     end
 end
@@ -159,7 +159,7 @@ function _fixup_Expr_children!(head, loc, args)
         arg = args[i]
         was_parens = @isexpr(arg, :parens)
         arg = _strip_parens(arg)
-        if @isexpr(arg, :(=)) && eq_to_kw_in_call && i > 1 
+        if @isexpr(arg, :(=)) && eq_to_kw_in_call && i > 1
             arg = Expr(:kw, arg.args...)
         elseif k != K"parens" && @isexpr(arg, :., 1) && arg.args[1] isa Tuple
             h, a = arg.args[1]::Tuple{SyntaxHead,Any}
@@ -489,13 +489,13 @@ struct _BuildExprStackEntry
 end
 
 function build_tree(::Type{Expr}, stream::ParseStream;
-                    filename=nothing, first_line=1, kws...)
+                    filename=nothing, first_line=1)
     source = SourceFile(stream, filename=filename, first_line=first_line)
     txtbuf = unsafe_textbuf(stream)
     args = Any[]
     childranges = UnitRange{Int}[]
     childheads = SyntaxHead[]
-    entry = build_tree(_BuildExprStackEntry, stream; kws...) do head, srcrange, nodechildren
+    entry = build_tree(_BuildExprStackEntry, stream) do head, srcrange, nodechildren
         if is_trivia(head) && !is_error(head)
             return nothing
         end
@@ -534,4 +534,3 @@ function Base.Expr(node::SyntaxNode)
     loc = source_location(LineNumberNode, node.source, first(range(node)))
     only(_fixup_Expr_children!(SyntaxHead(K"None",EMPTY_FLAGS), loc, Any[ex]))
 end
-

--- a/src/green_tree.jl
+++ b/src/green_tree.jl
@@ -87,11 +87,11 @@ function Base.show(io::IO, ::MIME"text/plain", node::GreenNode, str::AbstractStr
     _show_green_node(io, node, "", 1, str, show_trivia)
 end
 
-function build_tree(::Type{GreenNode}, stream::ParseStream; kws...)
-    build_tree(GreenNode{SyntaxHead}, stream; kws...) do h, srcrange, cs
+# we don't need the `filename` and `first_line` kwargs, but some trees do, so we allow them to be passed
+function build_tree(::Type{GreenNode}, stream::ParseStream; filename=nothing, first_line=nothing)
+    build_tree(GreenNode{SyntaxHead}, stream) do h, srcrange, cs
         span = length(srcrange)
         isnothing(cs) ? GreenNode(h, span, ()) :
                         GreenNode(h, span, collect(GreenNode{SyntaxHead}, cs))
     end
 end
-

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -994,7 +994,7 @@ end
 # API for extracting results from ParseStream
 
 """
-    build_tree(make_node::Function, ::Type{StackEntry}, stream::ParseStream; kws...)
+    build_tree(make_node::Function, ::Type{StackEntry}, stream::ParseStream)
 
 Construct a tree from a ParseStream using depth-first traversal. `make_node`
 must have the signature
@@ -1010,8 +1010,7 @@ wrap them in a single node.
 
 The tree here is constructed depth-first in postorder.
 """
-function build_tree(make_node::Function, ::Type{NodeType}, stream::ParseStream;
-                    kws...) where NodeType
+function build_tree(make_node::Function, ::Type{NodeType}, stream::ParseStream) where NodeType
     stack = Vector{NamedTuple{(:first_token,:node),Tuple{Int,NodeType}}}()
 
     tokens = stream.tokens

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -39,6 +39,9 @@
             Expr(:toplevel, LineNumberNode(2), :a, LineNumberNode(3), :b)
         @test parseall(Expr, "a\nb\n#==#") ==
             Expr(:toplevel, LineNumberNode(1), :a, LineNumberNode(2), :b)
+
+        # unknown kwargs error (#416)
+        @test_throws MethodError parseall(Expr, "a\nb"; ignore_error=true)
     end
 
     @testset "IO input" begin


### PR DESCRIPTION
closes https://github.com/JuliaLang/JuliaSyntax.jl/issues/416

My editor is configured to remove trailing whitespace, which caused some diffs here. Let me know if that's too annoying and I'll undo it.

Locally I get the test failures:

```julia
Parse core.jl: Test Failed at /Users/eph/JuliaSyntax.jl/test/test_utils.jl:237
  Expression: parsers_agree

Parse core.jl: Test Failed at /Users/eph/JuliaSyntax.jl/test/test_utils.jl:241
  Expression: reduced_failures == []
   Evaluated: AbstractString["for f() in 1:3\n        push!(a, f())\n        push!(fs, f)\n    end", " {{}}where{}"] == Any[]
```

same as in #420, which I think are unrelated.