### PR TITLE
add "some warnings detected" to ParseError printing when all problems are warnings

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -16,13 +16,16 @@ function ParseError(stream::ParseStream; incomplete_tag=:none, kws...)
 end
 
 function Base.showerror(io::IO, err::ParseError)
-    println(io, "ParseError:")
     # Only show the first parse error for now - later errors are often
     # misleading due to the way recovery works
     i = findfirst(is_error, err.diagnostics)
     if isnothing(i)
         i = lastindex(err.diagnostics)
+        level_info = " some warnings detected:"
+    else
+        level_info = " some errors detected:"
     end
+    println(io, "ParseError:", level_info)
     show_diagnostics(io, err.diagnostics[1:i], err.source)
 end
 

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -23,7 +23,7 @@ function Base.showerror(io::IO, err::ParseError)
         i = lastindex(err.diagnostics)
         level_info = " some warnings detected:"
     else
-        level_info = " some errors detected:"
+        level_info = ""
     end
     println(io, "ParseError:", level_info)
     show_diagnostics(io, err.diagnostics[1:i], err.source)

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -117,7 +117,7 @@ end
         if JuliaSyntax._has_v1_10_hooks
             @test err.args[1] isa Meta.ParseError
             exc = err.args[1]
-            @test exc.msg == "ParseError: some errors detected:\n# Error @ none:1:2\n\"\n#└ ── unterminated string literal"
+            @test exc.msg == "ParseError\n# Error @ none:1:2\n\"\n#└ ── unterminated string literal"
             @test exc.detail isa JuliaSyntax.ParseError
             @test exc.detail.incomplete_tag === :string
         else

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -117,7 +117,7 @@ end
         if JuliaSyntax._has_v1_10_hooks
             @test err.args[1] isa Meta.ParseError
             exc = err.args[1]
-            @test exc.msg == "ParseError:\n# Error @ none:1:2\n\"\n#└ ── unterminated string literal"
+            @test exc.msg == "ParseError: some errors detected:\n# Error @ none:1:2\n\"\n#└ ── unterminated string literal"
             @test exc.detail isa JuliaSyntax.ParseError
             @test exc.detail.incomplete_tag === :string
         else

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -117,7 +117,7 @@ end
         if JuliaSyntax._has_v1_10_hooks
             @test err.args[1] isa Meta.ParseError
             exc = err.args[1]
-            @test exc.msg == "ParseError\n# Error @ none:1:2\n\"\n#└ ── unterminated string literal"
+            @test exc.msg == "ParseError:\n# Error @ none:1:2\n\"\n#└ ── unterminated string literal"
             @test exc.detail isa JuliaSyntax.ParseError
             @test exc.detail.incomplete_tag === :string
         else

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -122,14 +122,14 @@ end
     catch exc
         @test exc isa JuliaSyntax.ParseError
         @test sprint(showerror, exc) == """
-            ParseError:
+            ParseError: some errors detected:
             # Error @ somefile.jl:1:3
             a -- b -- c
             # └┘ ── invalid operator"""
         @test occursin("Stacktrace:\n", sprint(showerror, exc, catch_backtrace()))
         file_url = JuliaSyntax._file_url("somefile.jl")
         @test sprint(showerror, exc, context=:color=>true) == """
-            ParseError:
+            ParseError: some errors detected:
             \e[90m# Error @ \e[0;0m\e]8;;$file_url#1:3\e\\\e[90msomefile.jl:1:3\e[0;0m\e]8;;\e\\
             a \e[48;2;120;70;70m--\e[0;0m b -- c
             \e[90m# └┘ ── \e[0;0m\e[91minvalid operator\e[0;0m"""
@@ -145,7 +145,7 @@ end
     catch exc
         @test exc isa JuliaSyntax.ParseError
         @test sprint(showerror, exc) == """
-            ParseError:
+            ParseError: some errors detected:
             # Warning @ somefile.jl:1:2
             @(a)
             #└─┘ ── parenthesizing macro names is unnecessary
@@ -163,7 +163,7 @@ end
     catch exc
         @test exc isa JuliaSyntax.ParseError
         @test sprint(showerror, exc) == """
-            ParseError:
+            ParseError: some warnings detected:
             # Warning @ somefile.jl:1:2
             @(a)
             #└─┘ ── parenthesizing macro names is unnecessary"""

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -122,14 +122,14 @@ end
     catch exc
         @test exc isa JuliaSyntax.ParseError
         @test sprint(showerror, exc) == """
-            ParseError: some errors detected:
+            ParseError:
             # Error @ somefile.jl:1:3
             a -- b -- c
             # └┘ ── invalid operator"""
         @test occursin("Stacktrace:\n", sprint(showerror, exc, catch_backtrace()))
         file_url = JuliaSyntax._file_url("somefile.jl")
         @test sprint(showerror, exc, context=:color=>true) == """
-            ParseError: some errors detected:
+            ParseError:
             \e[90m# Error @ \e[0;0m\e]8;;$file_url#1:3\e\\\e[90msomefile.jl:1:3\e[0;0m\e]8;;\e\\
             a \e[48;2;120;70;70m--\e[0;0m b -- c
             \e[90m# └┘ ── \e[0;0m\e[91minvalid operator\e[0;0m"""
@@ -145,7 +145,7 @@ end
     catch exc
         @test exc isa JuliaSyntax.ParseError
         @test sprint(showerror, exc) == """
-            ParseError: some errors detected:
+            ParseError:
             # Warning @ somefile.jl:1:2
             @(a)
             #└─┘ ── parenthesizing macro names is unnecessary


### PR DESCRIPTION
I totally missed that the `(..)` issue from #350 was a warning rather than an error; I think probably bc the bold red part says `ERROR: ParseError:` and then the very light part says "Warning". Here I propose add to text to make it clearer by emphasizing warning vs error on the first line.