### PR TITLE
Delete unused down option from parse_docstring

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -526,9 +526,9 @@ end
 # Parse docstrings attached by a space or single newline
 #
 # flisp: parse-docstring
-function parse_docstring(ps::ParseState, down=parse_eq)
+function parse_docstring(ps::ParseState)
     mark = position(ps)
-    down(ps)
+    parse_eq(ps)
     if peek_behind(ps).kind == K"string"
         is_doc = true
         k = peek(ps)
@@ -553,7 +553,7 @@ function parse_docstring(ps::ParseState, down=parse_eq)
             # """\n doc\n """ foo ==> (doc (string-s "doc\n") foo)
         end
         if is_doc
-            down(ps)
+            parse_eq(ps)
             emit(ps, mark, K"doc")
         end
     end


### PR DESCRIPTION
This is an NFC simplification of control flow.

After this merges, I plan to follow up with swapping the order of parse_public and parse_docstring and then adjusting the quote callsites of parse_eq to be parse_public. This should fix #51450 without allowing docstrings in quotes. (or, if we'd like, we can also allow docstrings in quotes)