### PR TITLE
Change AST for iterations to use `iteration` kind

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -1099,7 +1099,7 @@ register_kinds!(JuliaSyntax, 0, [
         # Comprehensions
         "generator"
         "filter"
-        "cartesian_iterator"
+        "iteration"
         "comprehension"
         "typed_comprehension"
         # Container for a single statement/atom plus any trivia and errors

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1075,7 +1075,7 @@ function parse_where_chain(ps0::ParseState, mark)
             # x where {T,S}  ==>  (where x (braces T S))
             # Also various nonsensical forms permitted
             # x where {T S}  ==>  (where x (bracescat (row T S)))
-            # x where {y for y in ys}  ==>  (where x (braces (generator y (= y ys))))
+            # x where {y for y in ys}  ==>  (where x (braces (generator y (iteration (in y ys)))))
             m = position(ps)
             bump(ps, TRIVIA_FLAG)
             ckind, cflags = parse_cat(ps, K"}", ps.end_symbol)
@@ -1578,7 +1578,7 @@ function parse_call_chain(ps::ParseState, mark, is_macrocall=false)
                 # T[x   y]  ==>  (typed_hcat T x y)
                 # T[x ; y]  ==>  (typed_vcat T x y)
                 # T[a b; c d]  ==>  (typed_vcat T (row a b) (row c d))
-                # T[x for x in xs]  ==>  (typed_comprehension T (generator x (= x xs)))
+                # T[x for x in xs]  ==>  (typed_comprehension T (generator x (iteration (in x xs))))
                 #v1.8: T[a ; b ;; c ; d]  ==>  (typed_ncat-2 T (nrow-1 a b) (nrow-1 c d))
                 outk = ckind == K"vect"          ? K"ref"                  :
                        ckind == K"hcat"          ? K"typed_hcat"           :
@@ -1798,8 +1798,8 @@ function parse_resword(ps::ParseState)
         bump_closing_token(ps, K"end")
         emit(ps, mark, K"while")
     elseif word == K"for"
-        # for x in xs end  ==>  (for (= x xs) (block))
-        # for x in xs, y in ys \n a \n end ==> (for (cartesian_iterator (= x xs) (= y ys)) (block a))
+        # for x in xs end  ==>  (for (iteration (in x xs)) (block))
+        # for x in xs, y in ys \n a \n end ==> (for (iteration (in x xs) (in y ys)) (block a))
         bump(ps, TRIVIA_FLAG)
         parse_iteration_specs(ps)
         parse_block(ps)
@@ -2621,11 +2621,11 @@ function parse_iteration_spec(ps::ParseState)
     if peek_behind(ps).orig_kind == K"outer"
         if peek_skip_newline_in_gen(ps) in KSet"= in ∈"
             # Not outer keyword
-            # outer = rhs        ==>  (= outer rhs)
-            # outer <| x = rhs   ==>  (= (call-i outer <| x) rhs)
+            # outer = rhs        ==>  (iteration (in outer rhs))
+            # outer <| x = rhs   ==>  (iteration (in (call-i outer <| x) rhs))
         else
-            # outer i = rhs      ==>  (= (outer i) rhs)
-            # outer (x,y) = rhs  ==>  (= (outer (tuple-p x y)) rhs)
+            # outer i = rhs      ==>  (iteration (in (outer i) rhs))
+            # outer (x,y) = rhs  ==>  (iteration (in (outer (tuple-p x y)) rhs))
             reset_node!(ps, position(ps), kind=K"outer", flags=TRIVIA_FLAG)
             parse_pipe_lt(ps)
             emit(ps, mark, K"outer")
@@ -2641,7 +2641,7 @@ function parse_iteration_spec(ps::ParseState)
         end
         # Or try parse_pipe_lt ???
     end
-    emit(ps, mark, K"=")
+    emit(ps, mark, K"in")
 end
 
 # Parse an iteration spec, or a comma separate list of such for for loops and
@@ -2649,9 +2649,7 @@ end
 function parse_iteration_specs(ps::ParseState)
     mark = position(ps)
     n_iters = parse_comma_separated(ps, parse_iteration_spec)
-    if n_iters > 1
-        emit(ps, mark, K"cartesian_iterator")
-    end
+    emit(ps, mark, K"iteration")
 end
 
 # flisp: parse-space-separated-exprs
@@ -2701,19 +2699,19 @@ end
 # Parse generators
 #
 # We represent generators quite differently from `Expr`:
-# * Cartesian products of iterators are grouped within cartesian_iterator
+# * Iteration variables and their iterators are grouped within K"iteration"
 #   nodes, as in the short form of `for` loops.
 # * The `generator` kind is used for both cartesian and flattened generators
 #
-# (x for a in as for b in bs) ==> (parens (generator x (= a as) (= b bs)))
-# (x for a in as, b in bs) ==> (parens (generator x (cartesian_iterator (= a as) (= b bs))))
-# (x for a in as, b in bs if z)  ==> (parens (generator x (filter (cartesian_iterator (= a as) (= b bs)) z)))
+# (x for a in as for b in bs) ==> (parens (generator x (iteration (in a as)) (iteration (in b bs))))
+# (x for a in as, b in bs) ==> (parens (generator x (iteration (in a as) (in b bs))))
+# (x for a in as, b in bs if z)  ==> (parens (generator x (filter (iteration (in a as) (in b bs)) z)))
 #
 # flisp: parse-generator
 function parse_generator(ps::ParseState, mark)
     while (t = peek_token(ps); kind(t) == K"for")
         if !preceding_whitespace(t)
-            # ((x)for x in xs)  ==>  (parens (generator (parens x) (error) (= x xs)))
+            # ((x)for x in xs)  ==>  (parens (generator (parens x) (error) (iteration (in x xs))))
             bump_invisible(ps, K"error", TRIVIA_FLAG,
                            error="Expected space before `for` in generator")
         end
@@ -2721,7 +2719,7 @@ function parse_generator(ps::ParseState, mark)
         iter_mark = position(ps)
         parse_iteration_specs(ps)
         if peek(ps) == K"if"
-            # (x for a in as if z) ==> (parens (generator x (filter (= a as) z)))
+            # (x for a in as if z) ==> (parens (generator x (filter (iteration (in a as)) z)))
             bump(ps, TRIVIA_FLAG)
             parse_cond(ps)
             emit(ps, iter_mark, K"filter")
@@ -2732,7 +2730,7 @@ end
 
 # flisp: parse-comprehension
 function parse_comprehension(ps::ParseState, mark, closer)
-    # [x for a in as] ==> (comprehension (generator x a in as))
+    # [x for a in as] ==> (comprehension (generator x (iteration (in a as))))
     ps = ParseState(ps, whitespace_newline=true,
                     space_sensitive=false,
                     end_symbol=false)
@@ -2982,8 +2980,8 @@ function parse_cat(ps::ParseState, closer, end_is_symbol)
         # [x       ==>  (vect x (error-t))
         parse_vect(ps, closer)
     elseif k == K"for"
-        # [x for a in as]  ==>  (comprehension (generator x (= a as)))
-        # [x \n\n for a in as]  ==>  (comprehension (generator x (= a as)))
+        # [x for a in as]  ==>  (comprehension (generator x (iteration (in a as))))
+        # [x \n\n for a in as]  ==>  (comprehension (generator x (iteration (in a as))))
         parse_comprehension(ps, mark, closer)
     else
         # [x y]  ==>  (hcat x y)
@@ -3139,8 +3137,7 @@ function parse_brackets(after_parse::Function,
                 continue
             elseif k == K"for"
                 # Generator syntax
-                # (x for a in as)       ==>  (parens (generator x (= a as)))
-                # (x \n\n for a in as)  ==>  (parens (generator x (= a as)))
+                # (x for a in as)  ==>  (parens (generator x (iteration (in a as))))
                 parse_generator(ps, mark)
             else
                 # Error - recovery done when consuming closing_kind


### PR DESCRIPTION
I got inspired to implement #432 as suggested there... This should be a complete implementation of that proposed solution, but may still need experimentation/thought to decide whether Cartesian iteration should be nested or flat.

---

The `=` node which has traditionally been used for iteration specifications in `for` loops and generators doesn't have normal assignment semantics. Let's consider

    for x in xs
        body
    end

which has been parsed as `(for (= x xs) (block body))`.

Problems:
* The iteration does create a binding for `x`, but not to the expression on the right hand side of the `=`.
* The user may use `in` or `∈` in the source code rather than `=`. The parser still uses a `=` node for consistency but this only emphasizes that there's something a bit weird going on.

So this use of `=` is not assignment; merely assignment-like.

In this change, we use a new `iteration` kind instead of `=` so the for loop parses as `(for (iteration x xs) (block body))` instead.

We also reuse `iteration` to replace the `cartesian_iteration` head - cartesian iteration is just an iteration with an even number of children greater than two. Being less specific here with the naming (omitting the "cartesian") seems appropriate in trying to represent the surface syntax; cartesian semantics come later in lowering and a macro may decide to do something else with the iteration spec.

These changes are also used for generators.

After the changes we have tree structures such as

    julia> parsestmt(SyntaxNode, "for i in is body end")
    line:col│ tree                                   │ file_name
       1:1  │[for]
       1:4  │  [iteration]
       1:5  │    i
       1:10 │    is
       1:12 │  [block]
       1:13 │    body

    julia> parsestmt(SyntaxNode, "for i in is, j in js body end")
    line:col│ tree                                   │ file_name
       1:1  │[for]
       1:4  │  [iteration]
       1:5  │    i
       1:10 │    is
       1:14 │    j
       1:19 │    js
       1:21 │  [block]
       1:22 │    body

    julia> parsestmt(SyntaxNode, "[a for i = is, j = js if z]")
    line:col│ tree                                   │ file_name
       1:1  │[comprehension]
       1:2  │  [generator]
       1:2  │    a
       1:7  │    [filter]
       1:7  │      [iteration]
       1:8  │        i
       1:12 │        is
       1:16 │        j
       1:20 │        js
       1:26 │      z

    julia> parsestmt(SyntaxNode, "[a for i = is for j = js if z]")
    line:col│ tree                                   │ file_name
       1:1  │[comprehension]
       1:2  │  [generator]
       1:2  │    a
       1:7  │    [iteration]
       1:8  │      i
       1:12 │      is
       1:18 │    [filter]
       1:18 │      [iteration]
       1:19 │        j
       1:23 │        js
       1:29 │      z