### PR TITLE
Update `Base.peek` docstring

### DIFF
--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -475,7 +475,7 @@ end
 end
 
 """
-    peek(stream [, n=1]; skip_newlines=false)
+    peek(stream::ParseStream [, n=1]; skip_newlines=false)
 
 Look ahead in the stream `n` tokens, returning the token kind. Comments and
 non-newline whitespace are skipped automatically. Whitespace containing a


### PR DESCRIPTION
When looking at the help for `peek` in the repl, the current docstring looks like it applies to all `IO`, so I added `::ParseStream` to make the docstring more specific. See also https://github.com/JuliaLang/julia/issues/54749