### PR TITLE
Run CI on 1.9 and prerelease

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,9 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
+          - '1.9'
           - '1'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
           - {os: 'ubuntu-latest', version: '1.8', arch: 'x86'}
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: 1.6
           arch: x64


### PR DESCRIPTION
- 1.9 is no longer 1
- pre is now available (see https://github.com/julia-actions/setup-julia?tab=readme-ov-file#examples)

Updates test config to conform to @davidanthoff's suggestion from #444, but does not fix broken 1.10 and 1.11.0-rc tests.