### PR TITLE
Fix tests

### DIFF
--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -314,7 +314,8 @@ function ParseStream(text::AbstractString, index::Integer=1; version=VERSION)
 end
 
 # IO-based cases
-function ParseStream(io::IOBuffer; version=VERSION)
+# TODO: switch ParseStream to use a Memory internally on newer versionsof Julia
+VERSION < v"1.11.0-DEV.753" && function ParseStream(io::IOBuffer; version=VERSION)
     ParseStream(io.data, io, position(io)+1, version)
 end
 function ParseStream(io::Base.GenericIOBuffer; version=VERSION)

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -314,7 +314,7 @@ function ParseStream(text::AbstractString, index::Integer=1; version=VERSION)
 end
 
 # IO-based cases
-# TODO: switch ParseStream to use a Memory internally on newer versionsof Julia
+# TODO: switch ParseStream to use a Memory internally on newer versions of Julia
 VERSION < v"1.11.0-DEV.753" && function ParseStream(io::IOBuffer; version=VERSION)
     ParseStream(io.data, io, position(io)+1, version)
 end

--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -9,10 +9,10 @@ end
 end
 
 base_path = let
-    p = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "base") 
+    p = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "base")
     if !isdir(p)
         # For julia 1.9 images.
-        p = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "src", "base") 
+        p = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "src", "base")
         if !isdir(p)
             error("source for Julia base not found")
         end
@@ -39,10 +39,10 @@ base_tests_path = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
             return nothing
         end
 
-        if endswith(f, "core.jl") 
+        if endswith(f, "core.jl")
             # The test
             # @test Union{Tuple{T}, Tuple{T,Int}} where {T} === widen_diagonal(Union{Tuple{T}, Tuple{T,Int}} where {T})
-            # depends on a JuliaSyntax bugfix and parses differently (wrong) using 
+            # depends on a JuliaSyntax bugfix and parses differently (wrong) using
             # flisp. This was added in julia#52228 and backported in julia#52045
             if v"1.10.0-rc1.39" <= VERSION
                 return nothing
@@ -50,6 +50,11 @@ base_tests_path = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
                 # Loose comparison due to `for f() = 1:3` syntax
                 return exprs_roughly_equal
             end
+        end
+
+        # subtype.jl also depends on the where precedence JuliaSyntax bugfix as of julia#53034
+        if endswith(f, "subtype.jl") && v"1.11.0-DEV.1382" <= VERSION
+            return nothing
         end
 
         return exprs_equal_no_linenum


### PR DESCRIPTION
- Don't assume (io::IOBuffer).data is a Vector on new versions of Julia
- Exclude test/subtype.jl from corpus due to new dependence on where precedence (#395)
