### PR TITLE
Ensure range returns valid indices

### DIFF
--- a/src/source_files.jl
+++ b/src/source_files.jl
@@ -118,7 +118,7 @@ end
 # TODO: Change view() here to `sourcetext` ?
 function Base.view(source::SourceFile, rng::AbstractUnitRange)
     i = first(rng) - source.byte_offset
-    j = prevind(source.code, last(rng) + 1 - source.byte_offset)
+    j = last(rng) - source.byte_offset
     SubString(source.code, i, j)
 end
 

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -133,7 +133,7 @@ function sourcetext(node::AbstractSyntaxNode)
 end
 
 function Base.range(node::AbstractSyntaxNode)
-    (node.position-1) .+ (1:span(node))
+    node.position:prevind(node.source.code, node.position + span(node))
 end
 
 source_line(node::AbstractSyntaxNode) = source_line(node.source, node.position)


### PR DESCRIPTION
This (maybe) kind of fixes https://github.com/JuliaLang/JuliaSyntax.jl/issues/457. It at least ensures that `range` always is a valid range that can be used to index into the source string, i.e. it moves the logic that fixes the indices returned by `last_byte` from `Base.view` into `Base.range`.

Still wondering, though, whether the proper fix wouldn't be to do something about `span`.