### PR TITLE
Fix parsing of `-1::Int` - signed literals with type assertions

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1211,6 +1211,7 @@ function parse_unary(ps::ParseState)
                 # -2*x    ==>  (call-i -2 * x)
                 # +0xff   ==>  0xff
                 bump_glue(ps, kind(t2), EMPTY_FLAGS)
+                parse_factor_with_initial_ex(ps, mark)
             end
             return
         end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -212,6 +212,7 @@ tests = [
         "-0b10010" => "(call-pre - 0x12)"
         "-0o22"    => "(call-pre - 0x12)"
         "-0x12"    => "(call-pre - 0x12)"
+        "-1::T"    => "(::-i -1 T)"
         # Standalone dotted operators are parsed as (|.| op)
         ".+"   =>  "(. +)"
         ".+\n" =>  "(. +)"


### PR DESCRIPTION
This syntax is normally not something you'd use, but it's very useful for `ccall`. Previously the parser just crashed on this kind of input - a bug which is also present in the old parser.