### PR TITLE
Move overload of Base.range() to JuliaSyntax.byte_range()

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,9 +54,18 @@ JuliaSyntax.flags
 
 see also predicates related to `flags`.
 
-## Syntax tree types
+## Syntax trees
+
+Syntax tree types:
 
 ```@docs
 JuliaSyntax.SyntaxNode
 JuliaSyntax.GreenNode
+```
+
+Functions applicable to syntax trees include everything in the sections on
+heads/kinds, and source file handling.
+
+```@docs
+JuliaSyntax.byte_range
 ```

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -40,7 +40,6 @@ end
 first_byte(d::Diagnostic) = d.first_byte
 last_byte(d::Diagnostic)  = d.last_byte
 is_error(d::Diagnostic)   = d.level === :error
-Base.range(d::Diagnostic) = first_byte(d):last_byte(d)
 
 # Make relative path into a file URL
 function _file_url(filename)
@@ -89,7 +88,7 @@ function show_diagnostic(io::IO, diagnostic::Diagnostic, source::SourceFile)
     _printstyled(io, "# $prefix @ ", fgcolor=:light_black)
     _printstyled(io, "$locstr", fgcolor=:light_black, href=file_href)
     print(io, "\n")
-    highlight(io, source, range(diagnostic),
+    highlight(io, source, byte_range(diagnostic),
               note=diagnostic.message, notecolor=color,
               context_lines_before=1, context_lines_after=0)
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -522,16 +522,16 @@ end
 function _to_expr(node::SyntaxNode)
     if !haschildren(node)
         offset, txtbuf = _unsafe_wrap_substring(sourcetext(node.source))
-        return _leaf_to_Expr(node.source, txtbuf, head(node), range(node) .+ offset, node)
+        return _leaf_to_Expr(node.source, txtbuf, head(node), byte_range(node) .+ offset, node)
     end
     cs = children(node)
     args = Any[_to_expr(c) for c in cs]
-    _internal_node_to_Expr(node.source, range(node), head(node), range.(cs), head.(cs), args)
+    _internal_node_to_Expr(node.source, byte_range(node), head(node), byte_range.(cs), head.(cs), args)
 end
 
 function Base.Expr(node::SyntaxNode)
     ex = _to_expr(node)
-    loc = source_location(LineNumberNode, node.source, first(range(node)))
+    loc = source_location(LineNumberNode, node.source, first(byte_range(node)))
     only(_fixup_Expr_children!(SyntaxHead(K"None",EMPTY_FLAGS), loc, Any[ex]))
 end
 

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -125,16 +125,19 @@ first_byte(node::AbstractSyntaxNode) = node.position
 last_byte(node::AbstractSyntaxNode)  = node.position + span(node) - 1
 
 """
+    byte_range(ex)
+
+Return the range of bytes which `ex` covers in the source text.
+"""
+byte_range(ex) = first_byte(ex):last_byte(ex)
+
+"""
     sourcetext(node)
 
 Get the full source text of a node.
 """
 function sourcetext(node::AbstractSyntaxNode)
-    view(node.source, range(node))
-end
-
-function Base.range(node::AbstractSyntaxNode)
-    (node.position-1) .+ (1:span(node))
+    view(node.source, byte_range(node))
 end
 
 source_line(node::AbstractSyntaxNode) = source_line(node.source, node.position)
@@ -299,7 +302,7 @@ function child_position_span(node::SyntaxNode, path::Int...)
 end
 
 function highlight(io::IO, node::SyntaxNode; kws...)
-    highlight(io, node.source, range(node); kws...)
+    highlight(io, node.source, byte_range(node); kws...)
 end
 
 function highlight(io::IO, source::SourceFile, node::GreenNode, path::Int...; kws...)

--- a/tools/check_all_packages.jl
+++ b/tools/check_all_packages.jl
@@ -39,7 +39,7 @@ Logging.with_logger(TerminalLogger()) do
                 mismatch_count += 1
                 failing_source = sprint(context=:color=>true) do io
                     for c in reduce_tree(parseall(SyntaxNode, text))
-                        JuliaSyntax.highlight(io, c.source, range(c), context_lines_inner=5)
+                        JuliaSyntax.highlight(io, c.source, JuliaSyntax.byte_range(c), context_lines_inner=5)
                         println(io, "\n")
                     end
                 end


### PR DESCRIPTION
This overload was a mistake - it doesn't really have the same semantics as compared to `Base.range()`

Fixes #417