### PR TITLE
Define `numchildren()` function

### DIFF
--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -108,6 +108,7 @@ end
 
 haschildren(node::TreeNode) = node.children !== nothing
 children(node::TreeNode) = (c = node.children; return c === nothing ? () : c)
+numchildren(node::TreeNode) = (isnothing(node.children) ? 0 : length(node.children))
 
 
 """


### PR DESCRIPTION
This is a useful generic function to compliment `children()` in the case that `children()` is slightly nontrivial, for example in implementing `JuliaLowering.SyntaxTree`