### PR TITLE
Generic `sourcefile()` function

### DIFF
--- a/src/source_files.jl
+++ b/src/source_files.jl
@@ -193,9 +193,26 @@ function _print_marker_line(io, prefix_str, str, underline, singleline, color,
     end
 end
 
+function highlight(io::IO, x; kws...)
+    highlight(io, sourcefile(x), byte_range(x); kws...)
+end
+
 """
-Print the lines of source code surrounding the given byte `range`, which is
-highlighted with background `color` and markers in the text.
+    highlight(io::IO, source::SourceFile, range::UnitRange;
+              color, note, notecolor,
+              context_lines_before, context_lines_inner, context_lines_after,
+    highlight(io, x; kws...)
+
+Print the lines of source code `source` surrounding the given byte `range`
+which is highlighted with background `color` and underlined with markers in the
+text. A `note` in `notecolor` may be provided as annotation.
+
+In the second form, `x` is an object with `sourcefile(x)` and `byte_range(x)`
+implemented.
+
+The context arguments `context_lines_before`, etc, refer to the number of
+lines of code which will be printed as context before and after, with `inner`
+referring to context lines inside a multiline region.
 """
 function highlight(io::IO, source::SourceFile, range::UnitRange;
                    color=(120,70,70), context_lines_before=2,

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -137,21 +137,16 @@ byte_range(ex) = first_byte(ex):last_byte(ex)
 Get the full source text of a node.
 """
 function sourcetext(node::AbstractSyntaxNode)
-    view(node.source, byte_range(node))
+    view(sourcefile(node), byte_range(node))
 end
 
-source_line(node::AbstractSyntaxNode) = source_line(node.source, node.position)
-source_location(node::AbstractSyntaxNode) = source_location(node.source, node.position)
-
-function interpolate_literal(node::SyntaxNode, val)
-    @assert kind(node) == K"$"
-    SyntaxNode(node.source, node.raw, node.position, node.parent, true, val)
-end
+source_line(node::AbstractSyntaxNode) = source_line(sourcefile(node), node.position)
+source_location(node::AbstractSyntaxNode) = source_location(sourcefile(node), node.position)
 
 function _show_syntax_node(io, current_filename, node::AbstractSyntaxNode,
                            indent, show_byte_offsets)
-    fname = node.source.filename
-    line, col = source_location(node.source, node.position)
+    fname = sourcefile(node).filename
+    line, col = source_location(node)
     posstr = "$(lpad(line, 4)):$(rpad(col,3))│"
     if show_byte_offsets
         posstr *= "$(lpad(first_byte(node),6)):$(rpad(last_byte(node),6))│"
@@ -299,10 +294,6 @@ end
 function child_position_span(node::SyntaxNode, path::Int...)
     n = child(node, path...)
     n, n.position, span(n)
-end
-
-function highlight(io::IO, node::SyntaxNode; kws...)
-    highlight(io, node.source, byte_range(node); kws...)
 end
 
 function highlight(io::IO, source::SourceFile, node::GreenNode, path::Int...; kws...)


### PR DESCRIPTION
* Having a generic version of this is useful for other syntax tree types such as `JuliaLowering.SyntaxTree`
* Function to get the `SourceFile` for a syntax object
* Generic `highlight()` implementation in terms of this