### PR TITLE
Cleanup/document source code access functions + add `filename()`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,14 +30,36 @@ JuliaSyntax.untokenize
 JuliaSyntax.Token
 ```
 
-## Source file handling
+## Source code handling
+
+This section describes the generic functions for source text, source location
+computation and formatting functions.
+
+Contiguous syntax objects like nodes in the syntax tree should implement the
+following where possible:
+
+```@docs
+JuliaSyntax.sourcefile
+JuliaSyntax.byte_range
+```
+
+This will provide implementations of the following which include range
+information, line numbers, and fancy highlighting of source ranges:
+
+```@docs
+JuliaSyntax.first_byte
+JuliaSyntax.last_byte
+JuliaSyntax.filename
+JuliaSyntax.source_line
+JuliaSyntax.source_location
+JuliaSyntax.sourcetext
+JuliaSyntax.highlight
+```
+
+`SourceFile`-specific functions:
 
 ```@docs
 JuliaSyntax.SourceFile
-JuliaSyntax.highlight
-JuliaSyntax.sourcetext
-JuliaSyntax.source_line
-JuliaSyntax.source_location
 JuliaSyntax.source_line_range
 ```
 
@@ -64,8 +86,5 @@ JuliaSyntax.GreenNode
 ```
 
 Functions applicable to syntax trees include everything in the sections on
-heads/kinds, and source file handling.
-
-```@docs
-JuliaSyntax.byte_range
-```
+heads/kinds as well as the accessor functions in the source code handling
+section.

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -37,8 +37,7 @@ function Diagnostic(first_byte, last_byte; error=nothing, warning=nothing)
     Diagnostic(first_byte, last_byte, level, message)
 end
 
-first_byte(d::Diagnostic) = d.first_byte
-last_byte(d::Diagnostic)  = d.last_byte
+byte_range(d::Diagnostic) = d.first_byte:d.last_byte
 is_error(d::Diagnostic)   = d.level === :error
 
 # Make relative path into a file URL
@@ -72,12 +71,12 @@ function show_diagnostic(io::IO, diagnostic::Diagnostic, source::SourceFile)
                    (:normal, "Info")
     line, col = source_location(source, first_byte(diagnostic))
     linecol = "$line:$col"
-    filename = source.filename
+    fname = filename(source)
     file_href = nothing
-    if !isnothing(filename)
-        locstr = "$filename:$linecol"
-        if !startswith(filename, "REPL[") && get(io, :color, false)
-            url = _file_url(filename)
+    if !isempty(fname)
+        locstr = "$fname:$linecol"
+        if !startswith(fname, "REPL[") && get(io, :color, false)
+            url = _file_url(fname)
             if !isnothing(url)
                 file_href = url*"#$linecol"
             end

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -514,8 +514,7 @@ struct FullToken
 end
 
 head(t::FullToken) = t.head
-first_byte(t::FullToken) = t.first_byte
-last_byte(t::FullToken) = t.last_byte
+byte_range(t::FullToken) = t.first_byte:t.last_byte
 span(t::FullToken) = 1 + last_byte(t) - first_byte(t)
 
 function peek_full_token(stream::ParseStream, n::Integer=1;

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -26,6 +26,8 @@ function Base.showerror(io::IO, err::ParseError)
     show_diagnostics(io, err.diagnostics[1:i], err.source)
 end
 
+sourcefile(err::ParseError) = err.source
+
 """
     parse!(stream::ParseStream; rule=:all)
 

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -121,31 +121,13 @@ head(node::AbstractSyntaxNode) = head(node.raw)
 
 span(node::AbstractSyntaxNode) = span(node.raw)
 
-first_byte(node::AbstractSyntaxNode) = node.position
-last_byte(node::AbstractSyntaxNode)  = node.position + span(node) - 1
+byte_range(node::AbstractSyntaxNode) = node.position:(node.position + span(node) - 1)
 
-"""
-    byte_range(ex)
-
-Return the range of bytes which `ex` covers in the source text.
-"""
-byte_range(ex) = first_byte(ex):last_byte(ex)
-
-"""
-    sourcetext(node)
-
-Get the full source text of a node.
-"""
-function sourcetext(node::AbstractSyntaxNode)
-    view(sourcefile(node), byte_range(node))
-end
-
-source_line(node::AbstractSyntaxNode) = source_line(sourcefile(node), node.position)
-source_location(node::AbstractSyntaxNode) = source_location(sourcefile(node), node.position)
+sourcefile(node::AbstractSyntaxNode) = node.source
 
 function _show_syntax_node(io, current_filename, node::AbstractSyntaxNode,
                            indent, show_byte_offsets)
-    fname = sourcefile(node).filename
+    fname = filename(node)
     line, col = source_location(node)
     posstr = "$(lpad(line, 4)):$(rpad(col,3))│"
     if show_byte_offsets
@@ -192,7 +174,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", node::AbstractSyntaxNode; show_byte_offsets=false)
     println(io, "line:col│$(show_byte_offsets ? " byte_range  │" : "") tree                                   │ file_name")
-    _show_syntax_node(io, Ref{Union{Nothing,String}}(nothing), node, "", show_byte_offsets)
+    _show_syntax_node(io, Ref(""), node, "", show_byte_offsets)
 end
 
 function Base.show(io::IO, ::MIME"text/x.sexpression", node::AbstractSyntaxNode)

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -35,13 +35,13 @@ end
             JuliaSyntax.core_parser_hook("[x)", "f1", 1, 0, :statement)
         )
         @test err isa JuliaSyntax.ParseError
-        @test err.source.filename == "f1"
+        @test filename(err) == "f1"
         @test err.source.first_line == 1
         err = _unwrap_parse_error(
             JuliaSyntax.core_parser_hook("[x)", "f2", 2, 0, :statement)
         )
         @test err isa JuliaSyntax.ParseError
-        @test err.source.filename == "f2"
+        @test filename(err) == "f2"
         @test err.source.first_line == 2
 
         # Errors including nontrivial offset indices

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -35,7 +35,8 @@ using .JuliaSyntax:
     fl_parse,
     highlight,
     tokenize,
-    untokenize
+    untokenize,
+    filename
 
 if VERSION < v"1.6"
     # Compat stuff which might not be in Base for older versions


### PR DESCRIPTION
* Move all source code access functions which refer to source locations and strings into the top of source_files.jl, and add some documentation for these.
* Add `filename()` function to determine source file name of a syntax object
* Also add a minor generalization to SyntaxNode->Expr conversion code to make Expr conversion general enough to allow it to also be used for JuliaLowering.SyntaxTree. (internal/experimental interface, for now)