### PR TITLE
Fix bug converting cmd string macros to Expr

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -231,10 +231,10 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
     if k == K"?"
         headsym = :if
     elseif k == K"macrocall"
-        if length(args) == 2 
+        if length(args) >= 2
             a2 = args[2]
             if @isexpr(a2, :macrocall) && kind(childheads[1]) == K"CmdMacroName"
-                # Fix up for custom cmd macros like `` foo`x` ``
+                # Fix up for custom cmd macros like foo`x`
                 args[2] = a2.args[3]
             end
         end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -673,6 +673,8 @@
         # Custom cmd macros
         @test parsestmt("foo`str`") ==
             Expr(:macrocall, Symbol("@foo_cmd"), LineNumberNode(1), "str")
+        @test parsestmt("foo`str`flag") ==
+            Expr(:macrocall, Symbol("@foo_cmd"), LineNumberNode(1), "str", "flag")
         @test parsestmt("foo```\n  a\n  b```") ==
             Expr(:macrocall, Symbol("@foo_cmd"), LineNumberNode(1), "a\nb")
         # Expr conversion distinguishes from explicit calls to a macro of the same name

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -452,7 +452,12 @@ tests = [
         "x\"s\"in"   => """(macrocall @x_str (string-r "s") "in")"""
         "x\"s\"2"    => """(macrocall @x_str (string-r "s") 2)"""
         "x\"s\"10.0" => """(macrocall @x_str (string-r "s") 10.0)"""
-        #
+        # Cmd macro sufficies
+        "x`s`y"    => """(macrocall @x_cmd (cmdstring-r "s") "y")"""
+        "x`s`end"  => """(macrocall @x_cmd (cmdstring-r "s") "end")"""
+        "x`s`in"   => """(macrocall @x_cmd (cmdstring-r "s") "in")"""
+        "x`s`2"    => """(macrocall @x_cmd (cmdstring-r "s") 2)"""
+        "x`s`10.0" => """(macrocall @x_cmd (cmdstring-r "s") 10.0)"""
     ],
     JuliaSyntax.parse_resword => [
         # In normal_context


### PR DESCRIPTION
Found when running the downstream tests in Base