### PR TITLE
Rename `haschildren()` to `is_leaf()`

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -526,7 +526,7 @@ end
 
 function _to_expr(node)
     file = sourcefile(node)
-    if !haschildren(node)
+    if is_leaf(node)
         offset, txtbuf = _unsafe_wrap_substring(sourcetext(file))
         return _leaf_to_Expr(file, txtbuf, head(node), byte_range(node) .+ offset, node)
     end

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -10,7 +10,7 @@ function _first_error(t::SyntaxNode)
     if is_error(t)
         return 0,t
     end
-    if haschildren(t)
+    if !is_leaf(t)
         for (i,c) in enumerate(children(t))
             if is_error(c)
                 return i,c

--- a/test/green_node.jl
+++ b/test/green_node.jl
@@ -2,7 +2,7 @@
     t = parsestmt(GreenNode, "aa + b")
 
     @test span(t) == 6
-    @test haschildren(t)
+    @test !is_leaf(t)
     @test head(t) == SyntaxHead(K"call", 0x0008)
     @test span.(children(t)) == [2,1,1,1,1]
     @test head.(children(t)) == [

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -28,7 +28,7 @@ using .JuliaSyntax:
     SyntaxHead,
     is_trivia,
     sourcetext,
-    haschildren,
+    is_leaf,
     children,
     child,
     fl_parseall,
@@ -276,14 +276,14 @@ function _reduce_tree(failing_subtrees, tree; exprs_equal=exprs_equal_no_linenum
     if equals_flisp_parse(exprs_equal, tree)
         return false
     end
-    if !haschildren(tree)
+    if is_leaf(tree)
         push!(failing_subtrees, tree)
         return true
     end
     had_failing_subtrees = false
-    if haschildren(tree)
+    if !is_leaf(tree)
         for child in children(tree)
-            if is_trivia(child) || !haschildren(child)
+            if is_trivia(child) || is_leaf(child)
                 continue
             end
             had_failing_subtrees |= _reduce_tree(failing_subtrees, child; exprs_equal=exprs_equal)


### PR DESCRIPTION
Unfortunately, `haschildren(x)` was a terrible name because it's not testing the same thing as `numchildren(x) == 0`!

In our ASTs
* Leaves of the tree correspond to tokens in the source text
* Internal nodes are containers for a range of tokens or other internal nodes.

Occasionally we can have internal nodes which have no tokens and thus have `numchildren(node) == 0`. These are, however, still "internal nodes" and we have `haschildren(node) === true` for these which makes no sense!