### PR TITLE
Clean up and document syntax tree child access API + mark public API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -124,13 +124,46 @@ JuliaSyntax.SHORT_FORM_FUNCTION_FLAG
 
 ## Syntax trees
 
-Syntax tree types:
+Access to the children of a tree node is provided by the functions
+
+```@docs
+JuliaSyntax.is_leaf
+JuliaSyntax.numchildren
+JuliaSyntax.children
+```
+
+For convenient access to the children, we also provide `node[i]`, `node[i:j]`
+and `node[begin:end]` by implementing `Base.getindex()`, `Base.firstindex()` and
+`Base.lastindex()`. We choose to return a view from `node[i:j]` to make it
+non-allocating.
+
+Tree traversal is supported by using these functions along with the predicates
+such as [`kind`](@ref) listed above.
+
+### Trees referencing the source
 
 ```@docs
 JuliaSyntax.SyntaxNode
+```
+
+Functions applicable to `SyntaxNode` include everything in the sections on
+heads/kinds as well as the accessor functions in the source code handling
+section.
+
+### Relocatable syntax trees
+
+[`GreenNode`](@ref) is a special low level syntax tree: it's "relocatable" in
+the sense that it doesn't carry an absolute position in the source code or even
+a reference to the source text. This allows it to be reused for incremental
+parsing, but does make it a pain to work with directly!
+
+```@docs
 JuliaSyntax.GreenNode
 ```
 
-Functions applicable to syntax trees include everything in the sections on
-heads/kinds as well as the accessor functions in the source code handling
-section.
+Green nodes only have a relative position so implement `span()` instead of
+`byte_range()`:
+
+```@docs
+JuliaSyntax.span
+```

--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -1,22 +1,80 @@
 module JuliaSyntax
 
-# Conservative list of exports - only export the most common/useful things
-# here.
+macro _public(syms)
+    if VERSION >= v"1.11"
+        names = syms isa Symbol ? [syms] : syms.args
+        esc(Expr(:public, names...))
+    else
+        nothing
+    end
+end
 
-# Parsing. See also
-#   parse!(), ParseStream
-export parsestmt, parseall, parseatom
+# Public API, in the order of docs/src/api.md
+
+# Parsing.
+export parsestmt,
+    parseall,
+    parseatom
+
+@_public parse!,
+    ParseStream,
+    build_tree
+
 # Tokenization
-export tokenize, Token, untokenize
-# Source file handling. See also
-#   highlight() sourcetext() source_line() source_location() char_range()
+@_public tokenize,
+    Token,
+    untokenize
+
+# Source file handling
+@_public sourcefile,
+    byte_range,
+    char_range,
+    first_byte,
+    last_byte,
+    filename,
+    source_line,
+    source_location,
+    sourcetext,
+    highlight
+
 export SourceFile
-# Expression heads/kinds. See also
-#   flags() and related predicates.
-export @K_str, kind, head
-# Syntax tree types. See also
-#   GreenNode
+@_public source_line_range
+
+# Expression predicates, kinds and flags
+export @K_str, kind
+@_public Kind
+
+@_public flags,
+    SyntaxHead,
+    head,
+    is_trivia,
+    is_prefix_call,
+    is_infix_op_call,
+    is_prefix_op_call,
+    is_postfix_op_call,
+    is_dotted,
+    is_suffixed,
+    is_decorated,
+    numeric_flags,
+    has_flags,
+    TRIPLE_STRING_FLAG,
+    RAW_STRING_FLAG,
+    PARENS_FLAG,
+    COLON_QUOTE,
+    TOPLEVEL_SEMICOLONS_FLAG,
+    MUTABLE_FLAG,
+    BARE_MODULE_FLAG,
+    SHORT_FORM_FUNCTION_FLAG
+
+# Syntax trees
+@_public is_leaf,
+    numchildren,
+    children
+
 export SyntaxNode
+
+@_public GreenNode,
+    span
 
 # Helper utilities
 include("utils.jl")

--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -21,7 +21,7 @@ export parsestmt,
     build_tree
 
 # Tokenization
-@_public tokenize,
+export tokenize,
     Token,
     untokenize
 

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -45,11 +45,8 @@ function _incomplete_tag(n::SyntaxNode, codelen)
             return :none
         end
     end
-    if kind(c) == K"error" && begin
-                cs = children(c)
-                length(cs) > 0
-            end
-        for cc in cs
+    if kind(c) == K"error" && numchildren(c) > 0
+        for cc in children(c)
             if kind(cc) == K"error"
                 return :other
             end

--- a/test/green_node.jl
+++ b/test/green_node.jl
@@ -13,6 +13,15 @@
          SyntaxHead(K"Identifier", 0x0000)
     ]
 
+    @test numchildren(t) == 5
+    @test !is_leaf(t)
+    @test is_leaf(t[1])
+
+    @test t[1] === children(t)[1]
+    @test t[2:4] == [t[2],t[3],t[4]]
+    @test firstindex(t) == 1
+    @test lastindex(t) == 5
+
     t2 = parsestmt(GreenNode, "aa + b")
     @test t == t2
     @test t !== t2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,6 @@
 using JuliaSyntax
 using Test
 
-using JuliaSyntax: SourceFile
-
-using JuliaSyntax: GreenNode, SyntaxNode,
-    flags, EMPTY_FLAGS, TRIVIA_FLAG, INFIX_FLAG,
-    children, child, setchild!, SyntaxHead
-
 include("test_utils.jl")
 include("test_utils_tests.jl")
 include("fuzz_test.jl")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,6 @@
 using Test
 
-# We need a relative include here as JuliaSyntax my come from Base.
+# We need a relative include here as JuliaSyntax may come from Base.
 using .JuliaSyntax:
     # Parsing
     ParseStream,
@@ -23,14 +23,15 @@ using .JuliaSyntax:
     # Node inspection
     kind,
     flags,
+    EMPTY_FLAGS, TRIVIA_FLAG, INFIX_FLAG,
     head,
     span,
     SyntaxHead,
     is_trivia,
     sourcetext,
     is_leaf,
+    numchildren,
     children,
-    child,
     fl_parseall,
     fl_parse,
     highlight,


### PR DESCRIPTION
Here I commit to a more consistent but simpler child access API for syntax trees, as informed by the JuliaLowering work so far:

* `is_leaf(node)` is given a precise definition (previously `!haschildren()` - but that had issues - see #483)
* `children(node)` returns the child list, or `nothing` if there are no children. The `nothing` might be seen as inconvenient, but mapping across the children of a leaf node is probably an error and one should probably branch on `is_leaf` first.
* `numchildren(node)` is documented
* `node[i]`, `node[i:j]` are documented to index into the child list

We distinguish `GreenNode` and its implementation of `span` from `SyntaxNode` and its implementation of `byte_range` and `sourcetext` - these seem to just have very different APIs, at least as of now.

I've deleted the questionable overloads of multidimensional `getindex` and the `child` function in favor of single dimensional getindex. I don't know whether anyone ever ended up using these. But I didn't and they didn't seem useful+consistent enough to keep the complexity.

I've kept setindex! for now, to set a child of a `SyntaxNode`. Though I'm not sure this is a good idea to support by default and I didn't mark it public yet.

Also I've added more docs!

Also mark the public parts of the API as `public` in Julia 1.11+