### PR TITLE
add some small type inference improvements to allow for some basic static compiling

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -484,7 +484,7 @@ function parse_block(ps::ParseState, down=parse_eq, mark=position(ps))
 end
 
 # Parse a block, but leave emitting the block up to the caller.
-function parse_block_inner(ps::ParseState, down)
+function parse_block_inner(ps::ParseState, down::F) where {F <: Function}
     parse_Nary(ps, down, KSet"NewlineWs ;", KSet"end else elseif catch finally")
 end
 
@@ -1602,7 +1602,7 @@ function parse_call_chain(ps::ParseState, mark, is_macrocall=false)
                        ckind == K"vcat"          ? K"typed_vcat"           :
                        ckind == K"comprehension" ? K"typed_comprehension"  :
                        ckind == K"ncat"          ? K"typed_ncat"           :
-                       internal_error("unrecognized kind in parse_cat ", ckind)
+                       internal_error("unrecognized kind in parse_cat ", string(ckind))
                 emit(ps, mark, outk, cflags)
                 check_ncat_compat(ps, mark, ckind)
             end
@@ -2020,7 +2020,7 @@ function parse_resword(ps::ParseState)
     elseif word == K"do"
         bump(ps, TRIVIA_FLAG, error="invalid `do` syntax")
     else
-        internal_error("unhandled reserved word ", word)
+        internal_error("unhandled reserved word ", string(word))
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,7 @@ _unsafe_wrap_substring(s) = (s.offset, unsafe_wrap(Vector{UInt8}, s.string))
 #--------------------------------------------------
 #
 # Internal error, used as assertion failure for cases we expect can't happen.
-@noinline function internal_error(strs...)
+@noinline function internal_error(strs::Vararg{String, N}) where {N}
     error("Internal error: ", strs...)
 end
 
@@ -27,7 +27,7 @@ end
 macro check(ex, msgs...)
     msg = isempty(msgs) ? ex : msgs[1]
     if isa(msg, AbstractString)
-        msg = msg
+        msg = String(msg)
     elseif !isempty(msgs) && (isa(msg, Expr) || isa(msg, Symbol))
         msg = :(string($(esc(msg))))
     else
@@ -133,4 +133,3 @@ function _printstyled(io::IO, text; fgcolor=nothing, bgcolor=nothing, href=nothi
         first = false
     end
 end
-


### PR DESCRIPTION
Allows the example in https://github.com/JuliaLang/JuliaSyntax.jl/issues/490 to compile (together with https://github.com/JuliaLang/julia/pull/55047#issuecomment-2277844004).