### PR TITLE
Consistent attachment of syntax trivia to top level statements

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -462,6 +462,7 @@ function parse_toplevel(ps::ParseState)
             bump_trivia(ps)
             break
         else
+            bump_trivia(ps)
             parse_stmts(ps)
         end
     end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -65,6 +65,21 @@
                           :body,
                      ),
                 )
+
+            @test parseall("a\n\nx") ==
+                Expr(:toplevel,
+                    LineNumberNode(1),
+                    :a,
+                    LineNumberNode(3),
+                    :x
+                )
+            @test parseall("a\n\nx;y") ==
+                Expr(:toplevel,
+                    LineNumberNode(1),
+                    :a,
+                    LineNumberNode(3),
+                    Expr(:toplevel, :x, :y)
+                )
         end
 
         @testset "Function definition lines" begin


### PR DESCRIPTION
Fix #494