### PR TITLE
Fix serialization of kinds with multibyte chars

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -66,7 +66,7 @@ end
 # can be serialized and deserialized across different JuliaSyntax versions.
 function Base.write(io::IO, k::Kind)
     str = convert(String, k)
-    write(io, UInt8(length(str))) + write(io, str)
+    write(io, UInt8(sizeof(str))) + write(io, str)
 end
 function Base.read(io::IO, ::Type{Kind})
     len = read(io, UInt8)

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -19,7 +19,7 @@ end
 end
 
 @testset "Serialization $T" for T in [Expr, SyntaxNode, JuliaSyntax.GreenNode]
-    x = JuliaSyntax.parsestmt(T, "f(x) = x + 2")
+    x = JuliaSyntax.parsestmt(T, "f(x) = x ⋅ 2")
     f = tempname()
     open(f, "w") do io
         serialize(io, x)


### PR DESCRIPTION
This patch fixes serialization of `Kind`s to use `sizeof` (number of bytes) instead of `length` (number of characters) when computing number of bytes in the stringified `Kind`.