### PR TITLE
Fix `incomplete_tag` generation with trailing whitespace

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -170,6 +170,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
             end
         end
         parse!(stream; rule=options)
+        pos_before_trivia = last_byte(stream)
         if options === :statement
             bump_trivia(stream; skip_newlines=false)
             if peek(stream) == K"NewlineWs"
@@ -179,7 +180,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
 
         if any_error(stream)
             tree = build_tree(SyntaxNode, stream, first_line=lineno, filename=filename)
-            tag = _incomplete_tag(tree, lastindex(code))
+            tag = _incomplete_tag(tree, pos_before_trivia)
             if _has_v1_10_hooks
                 exc = ParseError(stream, filename=filename, first_line=lineno,
                                  incomplete_tag=tag)

--- a/test/hooks.jl
+++ b/test/hooks.jl
@@ -181,6 +181,9 @@ end
                 "1, "          => :other
                 "1,\n"         => :other
                 "1, \n"        => :other
+                "f(1, "        => :other
+                "[x "          => :other
+                "( "           => :other
 
                 # Reference parser fails to detect incomplete exprs in this case
                 "(x for y"     => :other


### PR DESCRIPTION
Previously we relied on the last SyntaxNode consuming all trailing whitespace when detecting incomplete syntax. However this assumption was broken by #397 and is generally fragile with respect to any extra bump_trivia() calls. Fix this by just comparing to the stream position before any bumping of remaining trivia.

Should fix #512