### PR TITLE
Add `TRAILING_COMMA_FLAG` to distinguish `(a,b)` vs `(a,b,)`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -115,6 +115,7 @@ JuliaSyntax.has_flags
 JuliaSyntax.TRIPLE_STRING_FLAG
 JuliaSyntax.RAW_STRING_FLAG
 JuliaSyntax.PARENS_FLAG
+JuliaSyntax.TRAILING_COMMA_FLAG
 JuliaSyntax.COLON_QUOTE
 JuliaSyntax.TOPLEVEL_SEMICOLONS_FLAG
 JuliaSyntax.MUTABLE_FLAG


### PR DESCRIPTION
This syntax flag allows the stylistic choice of adding trailing commas to be easily detected. For example, `f(x)` vs `f(x,)` and `(a,b)` vs `(a,b,)`.
