### PR TITLE
Make left hand side of `->` parse as a tuple of arguments

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -70,6 +70,7 @@ class of tokenization errors and lets the parser deal with them.
 * Standalone dotted operators are always parsed as `(. op)`. For example `.*(x,y)` is parsed as `(call (. *) x y)` (#240)
 * The `K"="` kind is used for keyword syntax rather than `kw`, to avoid various inconsistencies and ambiguities (#103)
 * Unadorned postfix adjoint is parsed as `call` rather than as a syntactic operator for consistency with suffixed versions like `x'ᵀ` (#124)
+* The argument list in the left hand side of `->` is always a tuple. For example, `x->y` parses as `(-> (tuple x) y)` rather than `(-> x y)` (#522)
 
 ### Improvements to awkward AST forms
 

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -130,6 +130,10 @@
         @testset "->" begin
             @test parsestmt("a -> b") ==
                 Expr(:->, :a, Expr(:block, LineNumberNode(1), :b))
+            @test parsestmt("(a,) -> b") ==
+                Expr(:->, Expr(:tuple, :a), Expr(:block, LineNumberNode(1), :b))
+            @test parsestmt("(a where T) -> b") ==
+                Expr(:->, Expr(:where, :a, :T), Expr(:block, LineNumberNode(1), :b))
             # @test parsestmt("a -> (\nb;c)") ==
             #     Expr(:->, :a, Expr(:block, LineNumberNode(1), :b))
             @test parsestmt("a -> begin\nb\nc\nend") ==
@@ -137,6 +141,20 @@
                                    LineNumberNode(1),
                                    LineNumberNode(2), :b,
                                    LineNumberNode(3), :c))
+            @test parsestmt("(a;b=1) -> c") ==
+                Expr(:->,
+                     Expr(:block, :a, LineNumberNode(1), Expr(:(=), :b, 1)),
+                     Expr(:block, LineNumberNode(1), :c))
+            @test parsestmt("(a...;b...) -> c") ==
+                Expr(:->,
+                     Expr(:tuple, Expr(:parameters, Expr(:(...), :b)), Expr(:(...), :a)),
+                     Expr(:block, LineNumberNode(1), :c))
+            @test parsestmt("(;) -> c") ==
+                Expr(:->,
+                     Expr(:tuple, Expr(:parameters)),
+                     Expr(:block, LineNumberNode(1), :c))
+            @test parsestmt("a::T -> b") ==
+                Expr(:->, Expr(:(::), :a, :T), Expr(:block, LineNumberNode(1), :b))
         end
 
         @testset "elseif" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -288,9 +288,18 @@ tests = [
         "begin x end::T"  =>  "(::-i (block x) T)"
         # parse_decl_with_initial_ex
         "a::b"     =>  "(::-i a b)"
-        "a->b"     =>  "(-> a b)"
         "a::b::c"  =>  "(::-i (::-i a b) c)"
-        "a::b->c"  =>  "(-> (::-i a b) c)"
+        "a->b"     =>  "(-> (tuple a) b)"
+        "(a,b)->c" =>  "(-> (tuple-p a b) c)"
+        "(a;b=1)->c" =>  "(-> (tuple-p a (parameters (= b 1))) c)"
+        "x::T->c"  =>  "(-> (tuple (::-i x T)) c)"
+        # `where` combined with `->` still parses strangely. However:
+        # * It's extra hard to add a tuple around the `x` in this syntax corner case.
+        # * The user already needs to add additional, ugly, parens to get this
+        #   to parse correctly because the precendence of `where` is
+        #   inconsistent with `::` and `->` in this case.
+        "(x where T)->c" => "(-> (parens (where x T)) c)"
+        "((x::T) where T)->c" => "(-> (parens (where (parens (::-i x T)) T)) c)"
     ],
     JuliaSyntax.parse_unary_subtype => [
         "<: )"    =>  "<:"


### PR DESCRIPTION
This makes argument lists on the left hand side of `->` parse as tuples. In particular, this fixes a very inconsistent case where the left hand side previously parsed as a `K"block"`; we now have:

* `(a;x=1)->b` ==> `(-> (tuple-p a (parameters (= x 1))) b`

rather than `(block a (= x 1))` on the left hand side.

In addition, the following forms are treated consistently

* `a->b`       ==> `(-> (tuple a) b)`
* `(a)->b`     ==> `(-> (tuple-p a) b)`
* `(a,)->b`    ==> `(-> (tuple-p-, a) b)`

The upside of this is that expression processing of `->` syntax should be much easier.

There's one aberrant case involving `where` which is particularly difficult and still not dealt with:

`(x where T) -> b` does not parse as `(where (tuple x) T)` on the left hand side. However, `where` precedence involving `::` and `->` is already horribly broken and this syntax will always be awful to write unless we make breaking changes. So I'm too tempted to call this a lost cause for now 😬.

Compatibility shims for converting the `SyntaxNode` form back to `Expr` in order to keep `Expr` stable are included. (At some point we should consider fixing this and deleting these shims because the new form is so much more consistent and would be reflected neatly into `Expr` form.)