### PR TITLE
Parse non-syntactic operator tokens as `K"Identifier"` kind

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -297,7 +297,7 @@ function _internal_node_to_Expr(source, srcrange, head, childranges, childheads,
             if !@isexpr(a2, :quote) && !(a2 isa QuoteNode)
                 args[2] = QuoteNode(a2)
             end
-        elseif length(args) == 1 && is_operator(childheads[1])
+        elseif length(args) == 1
             # Hack: Here we preserve the head of the operator to determine whether
             # we need to coalesce it with the dot into a single symbol later on.
             args[1] = (childheads[1], args[1])

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -1230,3 +1230,12 @@ function is_whitespace(x)
     k = kind(x)
     return k == K"Whitespace" || k == K"NewlineWs" || k == K"Comment"
 end
+
+function is_syntactic_operator(x)
+    k = kind(x)
+    # TODO: Do we need to disallow dotted and suffixed forms when this is used
+    # in the parser? The lexer itself usually disallows such tokens, so it's
+    # not clear whether we need to handle them. (Though note `.->` is a
+    # token...)
+    return k in KSet"&& || . ... ->" || is_syntactic_assignment(k)
+end

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -890,7 +890,8 @@ function bump_split(stream::ParseStream, split_spec::Vararg{Any, N}) where {N}
     for (i, (nbyte, k, f)) in enumerate(split_spec)
         h = SyntaxHead(k, f)
         b = (i == length(split_spec)) ? tok.next_byte : b + nbyte
-        push!(stream.tokens, SyntaxToken(h, kind(tok), false, b))
+        orig_k = k == K"." ? K"." : kind(tok)
+        push!(stream.tokens, SyntaxToken(h, orig_k, false, b))
     end
     stream.peek_count = 0
     return position(stream)

--- a/test/green_node.jl
+++ b/test/green_node.jl
@@ -8,7 +8,7 @@
     @test head.(children(t)) == [
          SyntaxHead(K"Identifier", 0x0000)
          SyntaxHead(K"Whitespace", 0x0001)
-         SyntaxHead(K"+", 0x0000)
+         SyntaxHead(K"Identifier", 0x0000)
          SyntaxHead(K"Whitespace", 0x0001)
          SyntaxHead(K"Identifier", 0x0000)
     ]

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -170,7 +170,7 @@ end
     end
 end
 
-tokensplit(str) = [kind(tok) => untokenize(tok, str) for tok in tokenize(str)]
+tokensplit(str; kws...) = [kind(tok) => untokenize(tok, str) for tok in tokenize(str; kws...)]
 
 @testset "tokenize() API" begin
     # tokenize() is eager
@@ -178,6 +178,17 @@ tokensplit(str) = [kind(tok) => untokenize(tok, str) for tok in tokenize(str)]
 
     # . is a separate token from + in `.+`
     @test tokensplit("a .+ β") == [
+        K"Identifier" => "a",
+        K"Whitespace" => " ",
+        K"." => ".",
+        K"Identifier" => "+",
+        K"Whitespace" => " ",
+        K"Identifier" => "β",
+    ]
+
+    # + is kind K"+" when operators in identifier position are emitted as
+    # operator kinds.
+    @test tokensplit("a .+ β"; operators_as_identifiers=false) == [
         K"Identifier" => "a",
         K"Whitespace" => " ",
         K"." => ".",
@@ -189,6 +200,14 @@ tokensplit(str) = [kind(tok) => untokenize(tok, str) for tok in tokenize(str)]
     # Contextual keywords become identifiers where necessary
     @test tokensplit("outer = 1") == [
         K"Identifier" => "outer",
+        K"Whitespace" => " ",
+        K"=" => "=",
+        K"Whitespace" => " ",
+        K"Integer" => "1",
+    ]
+    # Including word operators
+    @test tokensplit("where = 1"; operators_as_identifiers=false) == [
+        K"Identifier" => "where",
         K"Whitespace" => " ",
         K"=" => "=",
         K"Whitespace" => " ",

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -25,7 +25,7 @@
 
     @test sprint(show, t) == "(call-i (call-i a * b) + c)"
     @test sprint(io->show(io, MIME("text/x.sexpression"), t, show_kind=true)) ==
-        "(call-i (call-i a::Identifier *::* b::Identifier) +::+ c::Identifier)"
+        "(call-i (call-i a::Identifier *::Identifier b::Identifier) +::Identifier c::Identifier)"
 
     @test sprint(highlight, t[1][3]) == "a*b + c\n# ╙"
     @test sprint(highlight, t.source, t.raw, 1, 3) == "a*b + c\n# ╙"
@@ -75,7 +75,7 @@ end
       f                                      :: Identifier
       [call-i]
         a                                    :: Identifier
-        *                                    :: *
+        *                                    :: Identifier
         b                                    :: Identifier
       c                                      :: Identifier
     """
@@ -88,7 +88,7 @@ end
        1:1  │     1:1     │  f                                      :: Identifier
        1:3  │     3:5     │  [call-i]
        1:3  │     3:3     │    a                                    :: Identifier
-       1:4  │     4:4     │    *                                    :: *
+       1:4  │     4:4     │    *                                    :: Identifier
        1:5  │     5:5     │    b                                    :: Identifier
        2:3  │    10:10    │  c                                      :: Identifier
     """


### PR DESCRIPTION
Most operators are semantically just normal identifiers after parsing so should get the Kind `K"Identifier"`. For example, after this change `a + b` parses with `K"Identifier"` kind for the `+` token.

As an exception, standalone syntactic ops keep their kind - they can't really be used in a sane way as identifiers or interpolated into expressions in the normal way because they have their own syntactic forms. This also helps us in `Expr` conversion where they also have their own rules for coalescing with dots, when dotted.

Also introduce a new keyword `operators_as_identifiers` to the `tokenize()` API to accommodate some simple uses of this API to colour token strings by operator type, even when the operator is semantically in identifier-position.

Fix #474 as a follow-on from #456

CC @fredrikekre 