### PR TITLE
Add U+1F8B2 🢲 as an operator

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -479,6 +479,7 @@ register_kinds!(JuliaSyntax, 0, [
         "↶"
         "↺"
         "↻"
+        "🢲"
     "END_ARROW"
 
     # Level 4

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -22,6 +22,7 @@ end
 function is_identifier_start_char(c::Char)
     c == EOF_CHAR && return false
     isvalid(c) || return false
+    c == '🢲' && return false  # First divergence from Base.is_id_start_char
     return Base.is_id_start_char(c)
 end
 

--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -920,6 +920,9 @@ end
     if VERSION >= v"1.10-DEV"
         push!(ops, "⥷ ⥺ ⟇")
     end
+    if VERSION >= v"1.12-DEV"
+        push!(ops, "🢲")
+    end
     allops = split(join(ops, " "), " ")
     @test all(s->Base.isoperator(Symbol(s)) == is_operator(first(collect(tokenize(s))).kind), allops)
 end

--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -920,11 +920,11 @@ end
     if VERSION >= v"1.10-DEV"
         push!(ops, "⥷ ⥺ ⟇")
     end
-    if VERSION >= v"1.12-DEV"
-        push!(ops, "🢲")
-    end
     allops = split(join(ops, " "), " ")
     @test all(s->Base.isoperator(Symbol(s)) == is_operator(first(collect(tokenize(s))).kind), allops)
+
+    # "\U1f8b2" added in Julia 1.12
+    @test is_operator(first(collect(tokenize("🢲"))))
 end
 
 const all_kws = Set([


### PR DESCRIPTION
The character U+1F8B2 🢲 (RIGHTWARDS ARROW WITH LOWER HOOK) is new is Unicode 16; it is of a kind (no pun intended) with the longstanding characters U+21A9 ↩ (LEFTWARDS ARROW WITH HOOK) and U+21AA ↪ (RIGHTWARDS ARROW WITH HOOK), both of which are already supported as operators in Julia.  If more evidence of its worth is needed, it was added to Unicode as part of the Symbols for Legacy Computing effort, wherein it was sourced from Smalltalk character sets in the 1970s—so it has a very long history of being used in programming languages!