### PR TITLE
Avoid adding tuple in parsing of `$(x) -> rhs`

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -293,6 +293,10 @@ tests = [
         "(a,b)->c" =>  "(-> (tuple-p a b) c)"
         "(a;b=1)->c" =>  "(-> (tuple-p a (parameters (= b 1))) c)"
         "x::T->c"  =>  "(-> (tuple (::-i x T)) c)"
+        "\$a->b"   =>  "(-> (tuple (\$ a)) b)"
+        "\$(a)->b" =>  "(-> (tuple (\$ (parens a))) b)"
+        # FIXME "&(a)->b"  =>  "(-> (tuple-p (& (parens a))) b)"
+        # FIXME "::(a)->b" =>  "(-> (tuple-p (:: (parens a))) b)"
         # `where` combined with `->` still parses strangely. However:
         # * It's extra hard to add a tuple around the `x` in this syntax corner case.
         # * The user already needs to add additional, ugly, parens to get this


### PR DESCRIPTION
Quick fix for https://github.com/JuliaLang/julia/issues/57223

This bug was brought on by the parsing change in #522.  Basically, we can't reliably look ahead at the `K"->"` token when parsing parentheses in `parse_paren()` if any construct with higher precedence is currently being parsed on the left hand side of the `$`.  Luckily there's very few such constructs, but `$` is one of these.

The others appear to be unary `&` and unary `::` which are also entangled in `where` parsing so are a bit more difficult to fix. Thus the obscure and probably useless syntaxes `::(x) -> y` and `&(x) -> y` are currently broken.

In principle, a way to fix this at the correct precedence level would be to rewrite the left hand side of `->` when bumping the `K"->"` token itself, and when the left hand side was a `K"parens"` node.  This almost works, but gets quite ugly for keyword parameters as in `(x; a=1) -> body` where we need to rewrite the left hand side from a block to a tuple with contained parameters node.