### PR TITLE
move code that converts input code to a `String` into its own function

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,6 +6,7 @@ let filename = joinpath(@__DIR__, "literal_parsing.jl")
     if _has_v1_6_hooks
         enable_in_core!()
         Meta.parse("1 + 2")
+        Meta.parse(SubString("1+2"))
         enable_in_core!(false)
     end
 end


### PR DESCRIPTION
Code that does simple input type transformations should generally be in its own function to avoid having to compile the full function for the different possible argument types. Also added a couple of type asserts in strategical places. 