### PR TITLE
also precompile for `SubString`

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,6 +6,7 @@ let filename = joinpath(@__DIR__, "literal_parsing.jl")
     if _has_v1_6_hooks
         enable_in_core!()
         Meta.parse("1 + 2")
+        Meta.parse(SubString("1 + 2"))
         enable_in_core!(false)
     end
 end


### PR DESCRIPTION
This has to be compiled now in the REPL otherwise:

```
precompile(Tuple{typeof(Base.JuliaSyntax.core_parser_hook), Base.SubString{String}, String, Int64, Int64, Symbol})
```