### PR TITLE
Update cache version to unbreak CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           version: 1.6
           arch: x64
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
GitHub yanked cahce@v1 (caused all jobs that use it to fail). This breaks our CI. This bump should fix it.