### PR TITLE
add `activate!` function as alias to `enable_in_core!`

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -580,8 +580,8 @@ end
 
 function build_tree(::Type{Tuple{Expr, SyntaxNode}}, stream::ParseStream;
                     filename=nothing, first_line=1, kws...)
-    syntaxtree = build_tree(SyntaxNode, stream, filename, first_line, kws...)
-    Expr.(syntaxtree)
+    syntaxtree = build_tree(SyntaxNode, stream; filename, first_line, kws...)
+    Expr(:toplevel, map(Expr, syntaxtree))
 end
 
 function _to_expr(node)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -577,13 +577,6 @@ function build_tree(::Type{Expr}, stream::ParseStream;
     only(_fixup_Expr_children!(SyntaxHead(K"None",EMPTY_FLAGS), loc, Any[entry.ex]))
 end
 
-
-function build_tree(::Type{Tuple{Expr, SyntaxNode}}, stream::ParseStream;
-                    filename=nothing, first_line=1, kws...)
-    syntaxtree = build_tree(SyntaxNode, stream; filename, first_line, kws...)
-    Expr(:toplevel, map(Expr, syntaxtree))
-end
-
 function _to_expr(node)
     file = sourcefile(node)
     if is_leaf(node)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -140,7 +140,7 @@ function _string_to_Expr(args)
         #   """\n  a\n  b""" ==>  "a\nb"
         return only(args2)
     else
-        # This only happens when the kind is K"string" or when an error has occurred. 
+        # This only happens when the kind is K"string" or when an error has occurred.
         return Expr(:string, args2...)
     end
 end
@@ -159,7 +159,7 @@ function _fixup_Expr_children!(head, loc, args)
         arg = args[i]
         was_parens = @isexpr(arg, :parens)
         arg = _strip_parens(arg)
-        if @isexpr(arg, :(=)) && eq_to_kw_in_call && i > 1 
+        if @isexpr(arg, :(=)) && eq_to_kw_in_call && i > 1
             arg = Expr(:kw, arg.args...)
         elseif k != K"parens" && @isexpr(arg, :., 1) && arg.args[1] isa Tuple
             h, a = arg.args[1]::Tuple{SyntaxHead,Any}
@@ -575,6 +575,13 @@ function build_tree(::Type{Expr}, stream::ParseStream;
     end
     loc = source_location(LineNumberNode, source, first(entry.srcrange))
     only(_fixup_Expr_children!(SyntaxHead(K"None",EMPTY_FLAGS), loc, Any[entry.ex]))
+end
+
+
+function build_tree(::Type{Tuple{Expr, SyntaxNode}}, stream::ParseStream;
+                    filename=nothing, first_line=1, kws...)
+    syntaxtree = build_tree(SyntaxNode, stream, filename, first_line, kws...)
+    Expr.(syntaxtree)
 end
 
 function _to_expr(node)

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -290,6 +290,10 @@ end
 
 _default_system_parser = _has_v1_6_hooks ? Core._parse : nothing
 
+
+# hook into InteractiveUtils.@activate
+activate!() = enable_in_core!()
+
 """
     enable_in_core!([enable=true; freeze_world_age=true, debug_filename=nothing])
 

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -136,11 +136,7 @@ end
 # Debug log file for dumping parsed code
 const _debug_log = Ref{Union{Nothing,IO}}(nothing)
 
-function core_parser_hook_for_lowering(code, filename::String, lineno::Int, offset::Int, options::Symbol)
-    core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol, true)
-end
-
-function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol, for_lowering=false)
+function core_parser_hook(code, filename::String, lineno::Int, offset::Int, options::Symbol)
     try
         # TODO: Check that we do all this input wrangling without copying the
         # code buffer
@@ -237,7 +233,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
             #
             # show_diagnostics(stdout, stream.diagnostics, code)
             #
-            ex = build_tree(for_lowering ? Tuple{Expr, SyntaxNode} : Expr, stream; filename=filename, first_line=lineno)
+            ex = build_tree(Expr, stream; filename=filename, first_line=lineno)
         end
 
         # Note the next byte in 1-based indexing is `last_byte(stream) + 1` but
@@ -294,9 +290,8 @@ end
 
 _default_system_parser = _has_v1_6_hooks ? Core._parse : nothing
 
-
 # hook into InteractiveUtils.@activate
-activate!(enable=true; for_lowering=false) = enable_in_core!(enable, for_lowering)
+activate!(enable=true) = enable_in_core!(enable)
 
 """
     enable_in_core!([enable=true; freeze_world_age=true, debug_filename=nothing])
@@ -312,7 +307,7 @@ Keyword arguments:
 * `debug_filename` - File name of parser debug log (defaults to `nothing` or
   the value of `ENV["JULIA_SYNTAX_DEBUG_FILE"]`).
 """
-function enable_in_core!(enable=true, for_lowering=false; freeze_world_age = true,
+function enable_in_core!(enable=true; freeze_world_age = true,
         debug_filename   = get(ENV, "JULIA_SYNTAX_DEBUG_FILE", nothing))
     if !_has_v1_6_hooks
         error("Cannot use JuliaSyntax as the main Julia parser in Julia version $VERSION < 1.6")
@@ -324,9 +319,8 @@ function enable_in_core!(enable=true, for_lowering=false; freeze_world_age = tru
         _debug_log[] = nothing
     end
     if enable
-        hook = for_lowering ? core_parser_hook_for_lowering : core_parser_hook
         world_age = freeze_world_age ? Base.get_world_counter() : typemax(UInt)
-        _set_core_parse_hook(fix_world_age(hook, world_age))
+        _set_core_parse_hook(fix_world_age(core_parser_hook, world_age))
     else
         @assert !isnothing(_default_system_parser)
         _set_core_parse_hook(_default_system_parser)

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -131,10 +131,15 @@ numchildren(node::TreeNode) = (isnothing(node.children) ? 0 : length(node.childr
 Base.getindex(node::AbstractSyntaxNode, i::Int) = children(node)[i]
 Base.getindex(node::AbstractSyntaxNode, rng::UnitRange) = view(children(node), rng)
 Base.firstindex(node::AbstractSyntaxNode) = 1
-Base.lastindex(node::AbstractSyntaxNode) = length(children(node))
+Base.length(node::AbstractSyntaxNode) = length(children(node))
+Base.lastindex(node::AbstractSyntaxNode) = length(node)
 
 function Base.setindex!(node::SN, x::SN, i::Int) where {SN<:AbstractSyntaxNode}
     children(node)[i] = x
+end
+
+function Base.iterate(A::AbstractSyntaxNode, i=1)
+    (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
 end
 
 """

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -138,10 +138,6 @@ function Base.setindex!(node::SN, x::SN, i::Int) where {SN<:AbstractSyntaxNode}
     children(node)[i] = x
 end
 
-function Base.iterate(A::AbstractSyntaxNode, i=1)
-    (@inline; (i - 1)%UInt < length(A)%UInt ? (@inbounds A[i], i + 1) : nothing)
-end
-
 """
     head(x)
 


### PR DESCRIPTION
This will allow for automatic hookup to be done via `InteractiveUtils.@activate JuliaSyntax`. 

TODO: On julia's end, we'll need to add JuliaSyntax to the components we're allowed to activate (and bump the JuliaSyntax version).