### PR TITLE
Make `source_location()` and SourceFile's and `line_starts` consistent when the last source byte is a newline

### DIFF
--- a/test/source_files.jl
+++ b/test/source_files.jl
@@ -3,23 +3,28 @@
     @test source_location(SourceFile("a"), 2) == (1,2)
 
     @test source_location(SourceFile("a\n"), 2) == (1,2)
-    @test source_location(SourceFile("a\n"), 3) == (1,3)
+    @test source_location(SourceFile("a\n"), 3) == (2,1)
 
     @test source_location(SourceFile("a\nb\n"), 2) == (1,2)
     @test source_location(SourceFile("a\nb\n"), 3) == (2,1)
     @test source_location(SourceFile("a\nb\n"), 4) == (2,2)
-    @test source_location(SourceFile("a\nb\n"), 5) == (2,3)
+    @test source_location(SourceFile("a\nb\n"), 5) == (3,1)
+
+    @test source_location(SourceFile("\n\n"), 1) == (1,1)
+    @test source_location(SourceFile("\n\n"), 2) == (2,1)
+    @test source_location(SourceFile("\n\n"), 3) == (3,1)
 
     @test source_location(SourceFile("a"; first_line=7), 1) == (7,1)
     @test source_location(SourceFile("a"; first_line=7), 2) == (7,2)
 
     @test source_location(SourceFile("a\n"; first_line=7), 2) == (7,2)
-    @test source_location(SourceFile("a\n"; first_line=7), 3) == (7,3)
+    @test source_location(SourceFile("a\n"; first_line=7), 3) == (8,1)
 
     @test source_location(SourceFile("a\nb\n"; first_line=7), 2) == (7,2)
     @test source_location(SourceFile("a\nb\n"; first_line=7), 3) == (8,1)
     @test source_location(SourceFile("a\nb\n"; first_line=7), 4) == (8,2)
-    @test source_location(SourceFile("a\nb\n"; first_line=7), 5) == (8,3)
+    @test source_location(SourceFile("a\nb\n"; first_line=7), 5) == (9,1)
+
 
     mktemp() do path, io
         write(io, "a\n")

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -37,6 +37,11 @@
     e = try node.val = :q catch e e end
     @test occursin("immutable", e.msg) && occursin("SyntaxData", e.msg)
 
+    # Newline-terminated source
+    t = parsestmt(SyntaxNode, "a*b + c\n")
+    @test sprint(highlight, t[1][3]) == "a*b + c\n# ╙"
+    @test sprint(highlight, t.source, t.raw, 1, 3) == "a*b + c\n# ╙"
+
     # copy
     t = parsestmt(SyntaxNode, "a*b + c")
     ct = copy(t)


### PR DESCRIPTION
When constructing SourceFile's `line_starts`, we currently pretend there's a
newline at the end of the source if there isn't one, and then ignore the last
newline unconditionally.  This became a problem in LSP testing, where calling
`source_location` with a cursor position at the end of the file would give a
wrong result only if the last character was a newline.

```
julia> source_location(SourceFile("\n\n\n"), 1)
(1, 1)

julia> source_location(SourceFile("\n\n\n"), 2)
(2, 1)

julia> source_location(SourceFile("\n\n\n"), 3)
(3, 1)

julia> source_location(SourceFile("\n\n\n"), 4)
(3, 2)
```

This change removes the conditional line and the code stripping it.  This also
brings `line_starts` closer to its definition (one entry per line in the file).

Alternatively, we could add the dummy line unconditionally.  It would make for
calculating the length of the last real line easier, but would make
`line_starts` less explainable.
