### PR TITLE
simple_hash faster by lifting length(str)

### DIFF
--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -1339,7 +1339,8 @@ end
 function simple_hash(str)
     ind = 1
     h = UInt64(0)
-    while ind <= length(str)
+    L = length(str)
+    while ind <= L
         h = simple_hash(str[ind], h)
         ind = nextind(str, ind)
     end

--- a/src/tokenize.jl
+++ b/src/tokenize.jl
@@ -1339,7 +1339,7 @@ end
 function simple_hash(str)
     ind = 1
     h = UInt64(0)
-    L = length(str)
+    L = min(lastindex(str), MAX_KW_LENGTH)
     while ind <= L
         h = simple_hash(str[ind], h)
         ind = nextind(str, ind)


### PR DESCRIPTION
avoids github.com/JuliaLang/julia/issues/33712, matches https://github.com/JuliaLang/Tokenize.jl/pull/213

probably rarely makes a difference but might as well; this should be strictly better.