### PR TITLE
kinds: rm unused kind K"inert"

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -526,8 +526,6 @@ end
     elseif k == K"module"
         pushfirst!(args, !has_flags(nodehead, BARE_MODULE_FLAG))
         pushfirst!((args[3]::Expr).args, loc)
-    elseif k == K"inert"
-        return QuoteNode(only(args))
     elseif k == K"quote"
         if length(args) == 1
             a1 = only(args)

--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -1015,7 +1015,6 @@ register_kinds!(JuliaSyntax, 0, [
         "dotcall"
         "comparison"
         "curly"
-        "inert"          # QuoteNode; not quasiquote
         "juxtapose"      # Numeric juxtaposition like 2x
         "string"         # A string interior node (possibly containing interpolations)
         "cmdstring"      # A cmd string node (containing delimiters plus string)


### PR DESCRIPTION
`inert` is mostly used in lowering. As far as I can tell, there is precisely one place in the flisp parser that produces it:

https://github.com/JuliaLang/julia/blob/d6b3669621ceb18aea693d8544b2c38870d289ad/src/julia-parser.scm#L1259

However, we do not insert and `inert` there in JuliaSyntax, instead preferring to automatically quote the rhs of a `.` head in expr conversion:

https://github.com/JuliaLang/JuliaSyntax.jl/blob/eceaa39706c6ecc3ef496613096216625dba558e/src/expr.jl#L310

As a result, (and as code coverage complains),  the syntax head is unused and should be removed here. However, it should probably then be added back in JuliaLowering.