### PR TITLE
Use implicit tree for error search

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -609,9 +609,12 @@ end
     return retexpr
 end
 
-function build_tree(::Type{Expr}, stream::ParseStream;
-                    filename=nothing, first_line=1, kws...)
+function build_tree(::Type{Expr}, stream::ParseStream; filename=nothing, first_line=1, kws...)
     source = SourceFile(stream, filename=filename, first_line=first_line)
+    return build_tree(Expr, stream, source)
+end
+
+function build_tree(::Type{Expr}, stream::ParseStream, source::SourceFile)
     txtbuf = unsafe_textbuf(stream)
     cursor = RedTreeCursor(stream)
     wrapper_head = SyntaxHead(K"wrapper",EMPTY_FLAGS)

--- a/src/tree_cursors.jl
+++ b/src/tree_cursors.jl
@@ -31,6 +31,12 @@ function prev_sibling_assumed(cursor::GreenTreeCursor)
     GreenTreeCursor(cursor.parser_output, next_idx)
 end
 
+function Base.in(child::GreenTreeCursor, parent::GreenTreeCursor)
+    @assert child.parser_output === parent.parser_output
+    child.position < parent.position || return false
+    return child.position >= parent.position - this(parent).node_span
+end
+
 # Debug printing
 function Base.show(io::IO, node::GreenTreeCursor)
     print(io, Base.summary(this(node)), " @", node.position)
@@ -164,3 +170,6 @@ end
     end
     nothing
 end
+
+Base.in(child::GreenTreeCursor, parent::RedTreeCursor) =
+    in(child, parent.green)


### PR DESCRIPTION
This builds on top of #560 and replaces the use of `SyntaxNode` in hooks.jl by the new lower-level cursor APIs. This avoid allocating two completely separate representations of the syntax tree.

As a result, the end-to-end parse time for error-containing code is between 1.5x (if the error is the first token) and 2x (if the error is the last token) faster than current master. However, the main motivation here is just to reduce coupling between the Expr-producing and SyntaxNode producing parts of the code.