### PR TITLE
Remove DOTOP_FLAG from tokenizer and parser

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,17 +1,17 @@
 The JuliaSyntax.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2021 Julia Computing and contributors
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/src/core/parse_stream.jl
+++ b/src/core/parse_stream.jl
@@ -376,7 +376,6 @@ function _buffer_lookahead_tokens(lexer, lookahead)
         was_whitespace = is_whitespace(k)
         had_whitespace |= was_whitespace
         f = EMPTY_FLAGS
-        raw.dotop      && (f |= DOTOP_FLAG)
         raw.suffix     && (f |= SUFFIXED_FLAG)
         push!(lookahead, SyntaxToken(SyntaxHead(k, f), k,
                                      had_whitespace, raw.endbyte + 2))

--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -313,9 +313,13 @@ end
         op = args[2]
         rhs = args[3]
         headstr = string(args[2], '=')
-        if is_dotted(nodehead)
-            headstr = '.'*headstr
-        end
+        retexpr.head = Symbol(headstr)
+        retexpr.args = Any[lhs, rhs]
+    elseif k == K".op=" && length(args) == 3
+        lhs = args[1]
+        op = args[2]
+        rhs = args[3]
+        headstr = '.' * string(args[2], '=')
         retexpr.head = Symbol(headstr)
         retexpr.args = Any[lhs, rhs]
     elseif k == K"macrocall"

--- a/src/julia/kinds.jl
+++ b/src/julia/kinds.jl
@@ -293,7 +293,9 @@ register_kinds!(JuliaSyntax, 0, [
     "BEGIN_ASSIGNMENTS"
         "BEGIN_SYNTACTIC_ASSIGNMENTS"
         "="
+        ".="
         "op="  # Updating assignment operator ( $= %= &= *= += -= //= /= <<= >>= >>>= \= ^= |= ÷= ⊻= )
+        ".op="
         ":="
         "END_SYNTACTIC_ASSIGNMENTS"
         "~"
@@ -470,11 +472,13 @@ register_kinds!(JuliaSyntax, 0, [
     # Level 4
     "BEGIN_LAZYOR"
         "||"
+        ".||"
     "END_LAZYOR"
 
     # Level 5
     "BEGIN_LAZYAND"
         "&&"
+        ".&&"
     "END_LAZYAND"
 
     # Level 6

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -78,7 +78,7 @@ end
     @test diagnostic("f(x, y #=hi=#\ng(z)") == Diagnostic(7, 6, :error, "Expected `)` or `,`")
     @test diagnostic("(x, y \nz") == Diagnostic(6, 5, :error, "Expected `)` or `,`")
     @test diagnostic("function f(x, y \nz end") == Diagnostic(16, 15, :error, "Expected `)` or `,`")
- 
+
     @test diagnostic("sin. (1)") ==
         Diagnostic(5, 5, :error, "whitespace is not allowed here")
     @test diagnostic("x [i]") ==


### PR DESCRIPTION
This implements the first of a series of AST format changes described in #567. In particular, this removes the DOTOP_FLAG. Currently, we already do not emit the DOTOP_FLAG on terminals, they always get split into one dot token and one identifier token (although we did set it on the intermediate tokens that came out of the lexer). The only four kinds for which DOTOP_FLAG was ever set in the final AST were `=`, `op=`, `&&` and `||`. This introduces separate head kinds for each of these (similar to how there are already separate head calls for `dotcall` and `dot). Otherwise the AST structure should be unchanged.