### PR TITLE
Refactor node-specific flags to overlap with numeric flags

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -890,6 +890,8 @@ tests = [
         "{x,y,}"     =>  "(braces-, x y)"
         "{x y}"      =>  "(bracescat (row x y))"
         ((v=v"1.7",), "{x ;;; y}") =>  "(bracescat (nrow-3 x y))"
+        ((v=v"1.7",), "{a ;; b}") =>  "(bracescat (nrow-2 a b))"
+        ((v=v"1.7",), "{a ;;;; b}") =>  "(bracescat (nrow-4 a b))"
         # Macro names can be keywords
         "@end x" => "(macrocall @end x)"
         # __dot__ macro
@@ -929,6 +931,11 @@ tests = [
         # Column major
         ((v=v"1.7",), "[x ; y ;; z ; w ;;; a ; b ;; c ; d]")  =>
             "(ncat-3 (nrow-2 (nrow-1 x y) (nrow-1 z w)) (nrow-2 (nrow-1 a b) (nrow-1 c d)))"
+        # Dimension 4 ncat
+        ((v=v"1.7",), "[x ;;;; y]")  =>  "(ncat-4 x y)"
+        ((v=v"1.7",), "[a ; b ;;;; c ; d]")  =>  "(ncat-4 (nrow-1 a b) (nrow-1 c d))"
+        ((v=v"1.7",), "[a b ; c d ;;;; e f ; g h]")  =>
+            "(ncat-4 (nrow-1 (row a b) (row c d)) (nrow-1 (row e f) (row g h)))"
         # Array separators
         # Newlines before semicolons are not significant
         "[a \n ;]"  =>  "(vcat a)"


### PR DESCRIPTION
As discussed in #567, this change moves node-specific flags (TRIPLE_STRING_FLAG, PARENS_FLAG, etc.) from bits 5-6 to overlap with numeric flags in bits 8-15. This is safe because:

1. Node types that use specific flags never use numeric flags
2. Numeric flags are only used by ncat/nrow nodes, which don't use node-specific flags
3. The parser now passes dimensions separately to avoid flag conflicts

This solves the problem of running out of flags space for now, but there still is a concern that we may want to tweak the representation for easy of macro manipulation. As discussed in #567, I think we should wait on that until we have some more actual code to decide on APIs. However, these changes should help in any case, since they split out the dim and the flags argument until the last moment.