### PR TITLE
build_tree: clarify accepted keyword arguments

### DIFF
--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -609,7 +609,10 @@ end
     return retexpr
 end
 
-function build_tree(::Type{Expr}, stream::ParseStream; filename=nothing, first_line=1, kws...)
+function build_tree(::Type{Expr}, stream::ParseStream;
+                    filename=nothing, first_line=1,
+                    # unused, but required since `_parse` is written generic
+                    keep_parens=false)
     source = SourceFile(stream, filename=filename, first_line=first_line)
     return build_tree(Expr, stream, source)
 end

--- a/src/porcelain/green_node.jl
+++ b/src/porcelain/green_node.jl
@@ -132,7 +132,9 @@ function GreenNode(cursor::GreenTreeCursor)
     end
 end
 
-function build_tree(T::Type{GreenNode}, stream::ParseStream; kws...)
+function build_tree(::Type{GreenNode}, stream::ParseStream;
+                    # unused, but required since `_parse` is written generic
+                    filename=nothing, first_line=1, keep_parens=false)
     cursor = GreenTreeCursor(stream)
     if has_toplevel_siblings(cursor)
         # There are multiple toplevel nodes, e.g. because we're using this

--- a/src/porcelain/syntax_tree.jl
+++ b/src/porcelain/syntax_tree.jl
@@ -302,7 +302,7 @@ end
 Base.copy(data::SyntaxData) = SyntaxData(data.source, data.raw, data.byte_end, data.val)
 
 function build_tree(::Type{SyntaxNode}, stream::ParseStream;
-                    filename=nothing, first_line=1, keep_parens=false, kws...)
+                    filename=nothing, first_line=1, keep_parens=false)
     source = SourceFile(stream, filename=filename, first_line=first_line)
     cursor = RedTreeCursor(stream)
     if has_toplevel_siblings(cursor)


### PR DESCRIPTION
Currently `build_tree` accepts extra `kwargs...` which causes actually invalid `kwargs...` to be silently ignored. This is particularly confusing since they can be mixed up with `_parse!` keyword arguments. This change clarifies which keyword arguments `build_tree` accepts and makes it explicitly error when invalid keyword arguments are passed.