### PR TITLE
Tweak macro name representation

### DIFF
--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -318,7 +318,7 @@ function adjust_macro_name!(retexpr::Union{Expr, Symbol}, k::Kind)
     end
 end
 
-# Split out from the above for codesize reasons, to avoid specialization on multiple
+# Split out from `node_to_expr` for codesize reasons, to avoid specialization on multiple
 # tree types.
 @noinline function _node_to_expr(retexpr::Expr, loc::LineNumberNode,
                                  srcrange::UnitRange{UInt32},

--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -246,8 +246,6 @@ function node_to_expr(cursor, source, txtbuf::Vector{UInt8}, txtbuf_offset::UInt
                         val isa UInt128 ? Symbol("@uint128_str") :
                         Symbol("@big_str")
                 return Expr(:macrocall, GlobalRef(Core, macname), nothing, str)
-            elseif k == K"MacroName" && val === Symbol("@.")
-                return Symbol("@__dot__")
             else
                 return val
             end
@@ -296,6 +294,30 @@ function node_to_expr(cursor, source, txtbuf::Vector{UInt8}, txtbuf_offset::UInt
                          nodehead, source)
 end
 
+function adjust_macro_name!(retexpr::Union{Expr, Symbol}, k::Kind)
+    if !(retexpr isa Symbol)
+        retexpr::Expr
+        # can happen for incomplete or errors
+        (length(retexpr.args) < 2 || retexpr.head != :(.)) && return retexpr
+        arg2 = retexpr.args[2]
+        isa(arg2, QuoteNode) || return retexpr
+        retexpr.args[2] = QuoteNode(adjust_macro_name!(arg2.value, k))
+        return retexpr
+    end
+    if k == K"macro_name"
+        if retexpr === Symbol(".")
+            return Symbol("@__dot__")
+        else
+            return Symbol("@$retexpr")
+        end
+    elseif k == K"macro_name_cmd"
+        return Symbol("@$(retexpr)_cmd")
+    else
+        @assert k == K"macro_name_str"
+        return Symbol("@$(retexpr)_str")
+    end
+end
+
 # Split out from the above for codesize reasons, to avoid specialization on multiple
 # tree types.
 @noinline function _node_to_expr(retexpr::Expr, loc::LineNumberNode,
@@ -312,6 +334,8 @@ end
         # However, errors can add additional errors tokens which we represent
         # as e.g. `Expr(:var, ..., Expr(:error))`.
         return retexpr.args[1]
+    elseif k in KSet"macro_name macro_name_cmd macro_name_str"
+        return adjust_macro_name!(retexpr.args[1], k)
     elseif k == K"?"
         retexpr.head = :if
     elseif k == K"op=" && length(args) == 3
@@ -331,7 +355,7 @@ end
     elseif k == K"macrocall"
         if length(args) >= 2
             a2 = args[2]
-            if @isexpr(a2, :macrocall) && kind(firstchildhead) == K"CmdMacroName"
+            if @isexpr(a2, :macrocall) && kind(firstchildhead) == K"macro_name_cmd"
                 # Fix up for custom cmd macros like foo`x`
                 args[2] = a2.args[3]
             end

--- a/src/julia/kinds.jl
+++ b/src/julia/kinds.jl
@@ -194,15 +194,6 @@ register_kinds!(JuliaSyntax, 0, [
     "BEGIN_IDENTIFIERS"
         "Identifier"
         "Placeholder" # Used for empty catch variables, and all-underscore identifiers in lowering
-        # Macro names are modelled as special kinds of identifiers because the full
-        # macro name may not appear as characters in the source: The `@` may be
-        # detached from the macro name as in `@A.x` (ugh!!), or have a _str or _cmd
-        # suffix appended.
-        "BEGIN_MACRO_NAMES"
-            "MacroName"
-            "StringMacroName"
-            "CmdMacroName"
-        "END_MACRO_NAMES"
     "END_IDENTIFIERS"
 
     "BEGIN_KEYWORDS"
@@ -1048,6 +1039,10 @@ register_kinds!(JuliaSyntax, 0, [
         "iteration"
         "comprehension"
         "typed_comprehension"
+        # Macro names
+        "macro_name"
+        "macro_name_cmd"
+        "macro_name_str"
         # Container for a single statement/atom plus any trivia and errors
         "wrapper"
     "END_SYNTAX_KINDS"
@@ -1111,10 +1106,6 @@ const _nonunique_kind_names = Set([
     K"String"
     K"Char"
     K"CmdString"
-
-    K"MacroName"
-    K"StringMacroName"
-    K"CmdMacroName"
 ])
 
 """
@@ -1201,7 +1192,6 @@ is_prec_unicode_ops(x) = K"BEGIN_UNICODE_OPS" <= kind(x) <= K"END_UNICODE_OPS"
 is_prec_pipe_lt(x)     = kind(x) == K"<|"
 is_prec_pipe_gt(x)     = kind(x) == K"|>"
 is_syntax_kind(x)      = K"BEGIN_SYNTAX_KINDS"<= kind(x) <= K"END_SYNTAX_KINDS"
-is_macro_name(x)       = K"BEGIN_MACRO_NAMES" <= kind(x) <= K"END_MACRO_NAMES"
 is_syntactic_assignment(x) = K"BEGIN_SYNTACTIC_ASSIGNMENTS" <= kind(x) <= K"END_SYNTACTIC_ASSIGNMENTS"
 
 function is_string_delim(x)

--- a/src/julia/literal_parsing.jl
+++ b/src/julia/literal_parsing.jl
@@ -430,12 +430,6 @@ function parse_julia_literal(txtbuf::Vector{UInt8}, head::SyntaxHead, srcrange)
             Symbol(normalize_identifier(val_str))
     elseif k == K"error"
         ErrorVal()
-    elseif k == K"MacroName"
-        Symbol("@$(normalize_identifier(val_str))")
-    elseif k == K"StringMacroName"
-        Symbol("@$(normalize_identifier(val_str))_str")
-    elseif k == K"CmdMacroName"
-        Symbol("@$(normalize_identifier(val_str))_cmd")
     elseif is_syntax_kind(head)
         nothing
     elseif is_keyword(k)

--- a/src/julia/tokenize.jl
+++ b/src/julia/tokenize.jl
@@ -1168,30 +1168,21 @@ end
 function lex_dot(l::Lexer)
     if accept(l, '.')
         if accept(l, '.')
+            l.last_token == K"@" && return emit(l, K"Identifier")
             return emit(l, K"...")
         else
             if is_dottable_operator_start_char(peekchar(l))
                 readchar(l)
                 return emit(l, K"ErrorInvalidOperator")
             else
+                l.last_token == K"@" && return emit(l, K"Identifier")
                 return emit(l, K"..")
             end
         end
     elseif Base.isdigit(peekchar(l))
         return lex_digit(l, K"Float")
     else
-        pc, dpc = dpeekchar(l)
-        # When we see a dot followed by an operator, we want to emit just the dot
-        # and let the next token be the operator
-        if is_operator_start_char(pc) || (pc == '!' && dpc == '=')
-            return emit(l, K".")
-        elseif pc == '÷'
-            return emit(l, K".")
-        elseif pc == '=' && dpc == '>'
-            return emit(l, K".")
-        elseif is_dottable_operator_start_char(pc)
-            return emit(l, K".")
-        end
+        l.last_token == K"@" && return emit(l, K"Identifier")
         return emit(l, K".")
     end
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -53,7 +53,7 @@ end
         Diagnostic(1, 9, :error, "try without catch or finally")
     # TODO: better range
 	@test diagnostic("@A.\$x a") ==
-        Diagnostic(6, 5, :error, "invalid macro name")
+        Diagnostic(4, 5, :error, "invalid macro name")
 
 	@test diagnostic("a, , b") ==
         Diagnostic(4, 4, :error, "unexpected `,`")

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -554,6 +554,7 @@
 
         # var""
         @test parsestmt("@var\"#\" a") == Expr(:macrocall, Symbol("@#"), LineNumberNode(1), :a)
+        @test parsestmt("@var\"\\\"\" a") == Expr(:macrocall, Symbol("@\""), LineNumberNode(1), :a)
         @test parsestmt("A.@var\"#\" a") == Expr(:macrocall, Expr(:., :A, QuoteNode(Symbol("@#"))), LineNumberNode(1), :a)
 
         # Square brackets

--- a/test/green_node.jl
+++ b/test/green_node.jl
@@ -33,8 +33,9 @@
          1:1      │  Identifier             ✔
          2:2      │  (
          3:7      │  [macrocall]
-         3:3      │    @
-         4:4      │    MacroName            ✔
+         3:4      │    [macro_name]
+         3:3      │      @
+         4:4      │      Identifier         ✔
          5:5      │    (
          6:6      │    Identifier           ✔
          7:7      │    )
@@ -50,8 +51,9 @@
          1:1      │  Identifier             ✔   "f"
          2:2      │  (                          "("
          3:7      │  [macrocall]
-         3:3      │    @                        "@"
-         4:4      │    MacroName            ✔   "x"
+         3:4      │    [macro_name]
+         3:3      │      @                      "@"
+         4:4      │      Identifier         ✔   "x"
          5:5      │    (                        "("
          6:6      │    Identifier           ✔   "y"
          7:7      │    )                        ")"

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -455,6 +455,11 @@ tests = [
         "@S{a,b}" => "(macrocall (macro_name S) (braces a b))"
         "A.@S{a}" => "(macrocall (. A (macro_name S)) (braces a))"
         "@S{a}.b" => "(. (macrocall (macro_name S) (braces a)) b)"
+        # Macro calls with chained operations
+        "@a[b][c]" => "(ref (macrocall (macro_name a) (vect b)) c)"
+        "@a{b}{c}" => "(curly (macrocall (macro_name a) (braces b)) c)"
+        "@a[b]{c}" => "(curly (macrocall (macro_name a) (vect b)) c)"
+        "@a{b}[c]" => "(ref (macrocall (macro_name a) (braces b)) c)"
         "S{a,b}"  => "(curly S a b)"
         "T{y for x = xs; a}" => "(curly T (generator y (iteration (in x xs))) (parameters a))"
         # String macros

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -345,37 +345,37 @@ tests = [
         ".&(x,y)" =>  "(call (. &) x y)"
         # parse_call_chain
         "f(a).g(b)" => "(call (. (call f a) g) b)"
-        "\$A.@x"    =>  "(macrocall (. (\$ A) @x))"
+        "\$A.@x"    =>  "(macrocall (. (\$ A) (macro_name x)))"
 
         # non-errors in space sensitive contexts
         "[f (x)]"    =>  "(hcat f (parens x))"
         "[f x]"      =>  "(hcat f x)"
         # space separated macro calls
-        "@foo a b"     =>  "(macrocall @foo a b)"
-        "@foo (x)"     =>  "(macrocall @foo (parens x))"
-        "@foo (x,y)"   =>  "(macrocall @foo (tuple-p x y))"
-        "A.@foo a b"   =>  "(macrocall (. A @foo) a b)"
-        "@A.foo a b"   =>  "(macrocall (. A @foo) a b)"
-        "[@foo x]"     =>  "(vect (macrocall @foo x))"
-        "[@foo]"       =>  "(vect (macrocall @foo))"
-        "@var\"#\" a"  =>  "(macrocall (var @#) a)"
-        "@(A) x"       =>  "(macrocall (parens @A) x)"
-        "A.@x y"       =>  "(macrocall (. A @x) y)"
-        "A.@var\"#\" a"=>  "(macrocall (. A (var @#)) a)"
-        "@+x y"        =>  "(macrocall @+ x y)"
-        "A.@.x"        =>  "(macrocall (. A @.) x)"
+        "@foo a b"     =>  "(macrocall (macro_name foo) a b)"
+        "@foo (x)"     =>  "(macrocall (macro_name foo) (parens x))"
+        "@foo (x,y)"   =>  "(macrocall (macro_name foo) (tuple-p x y))"
+        "A.@foo a b"   =>  "(macrocall (. A (macro_name foo)) a b)"
+        "@A.foo a b"   =>  "(macrocall (macro_name (. A foo)) a b)"
+        "[@foo x]"     =>  "(vect (macrocall (macro_name foo) x))"
+        "[@foo]"       =>  "(vect (macrocall (macro_name foo)))"
+        "@var\"#\" a"  =>  "(macrocall (macro_name (var #)) a)"
+        "@(A) x"       =>  "(macrocall (macro_name (parens A)) x)"
+        "A.@x y"       =>  "(macrocall (. A (macro_name x)) y)"
+        "A.@var\"#\" a"=>  "(macrocall (. A (macro_name (var #))) a)"
+        "@+x y"        =>  "(macrocall (macro_name +) x y)"
+        "A.@.x"        =>  "(macrocall (. A (macro_name .)) x)"
         # Macro names
-        "@! x"  => "(macrocall @! x)"
-        "@.. x" => "(macrocall @.. x)"
-        "@\$ y"  => "(macrocall @\$ y)"
-        "@[x] y z" => "(macrocall (error (vect x)) y z)"
+        "@! x"  => "(macrocall (macro_name !) x)"
+        "@.. x" => "(macrocall (macro_name ..) x)"
+        "@\$ y"  => "(macrocall (macro_name \$) y)"
+        "@[x] y z" => "(macrocall (macro_name (error (vect x))) y z)"
         # Special @doc parsing rules
-        "@doc x\ny"    =>  "(macrocall @doc x y)"
-        "A.@doc x\ny"  =>  "(macrocall (. A @doc) x y)"
-        "@A.doc x\ny"  =>  "(macrocall (. A @doc) x y)"
-        "@doc x y\nz"  =>  "(macrocall @doc x y)"
-        "@doc x\n\ny"  =>  "(macrocall @doc x)"
-        "@doc x\nend"  =>  "(macrocall @doc x)"
+        "@doc x\ny"    =>  "(macrocall (macro_name doc) x y)"
+        "A.@doc x\ny"  =>  "(macrocall (. A (macro_name doc)) x y)"
+        "@A.doc x\ny"  =>  "(macrocall (macro_name (. A doc)) x y)"
+        "@doc x y\nz"  =>  "(macrocall (macro_name doc) x y)"
+        "@doc x\n\ny"  =>  "(macrocall (macro_name doc) x)"
+        "@doc x\nend"  =>  "(macrocall (macro_name doc) x)"
 
         # calls with brackets
         "f(a,b)"  => "(call f a b)"
@@ -384,26 +384,26 @@ tests = [
         "f(a; b; c)" => "(call f a (parameters b) (parameters c))"
         "(a=1)()" =>  "(call (parens (= a 1)))"
         "f (a)" => "(call f (error-t) a)"
-        "@x(a, b)"   =>  "(macrocall-p @x a b)"
-        "@x(a, b,)"  =>  "(macrocall-p-, @x a b)"
-        "A.@x(y)"    =>  "(macrocall-p (. A @x) y)"
-        "A.@x(y).z"  =>  "(. (macrocall-p (. A @x) y) z)"
+        "@x(a, b)"   =>  "(macrocall-p (macro_name x) a b)"
+        "@x(a, b,)"  =>  "(macrocall-p-, (macro_name x) a b)"
+        "A.@x(y)"    =>  "(macrocall-p (. A (macro_name x)) y)"
+        "A.@x(y).z"  =>  "(. (macrocall-p (. A (macro_name x)) y) z)"
         "f(y for x = xs; a)" => "(call f (generator y (iteration (in x xs))) (parameters a))"
         # do
         "f() do\nend"         =>  "(call f (do (tuple) (block)))"
         "f() do ; body end"   =>  "(call f (do (tuple) (block body)))"
         "f() do x, y\n body end"  =>  "(call f (do (tuple x y) (block body)))"
         "f(x) do y body end"  =>  "(call f x (do (tuple y) (block body)))"
-        "@f(x) do y body end" =>  "(macrocall-p @f x (do (tuple y) (block body)))"
+        "@f(x) do y body end" =>  "(macrocall-p (macro_name f) x (do (tuple y) (block body)))"
 
         # square brackets
-        "@S[a,b]"  => "(macrocall @S (vect a b))"
-        "@S[a b]"  => "(macrocall @S (hcat a b))"
-        "@S[a; b]" => "(macrocall @S (vcat a b))"
-        "A.@S[a]"  =>  "(macrocall (. A @S) (vect a))"
-        "@S[a].b"  =>  "(. (macrocall @S (vect a)) b)"
-        ((v=v"1.7",), "@S[a ;; b]")  =>  "(macrocall @S (ncat-2 a b))"
-        ((v=v"1.6",), "@S[a ;; b]")  =>  "(macrocall @S (error (ncat-2 a b)))"
+        "@S[a,b]"  => "(macrocall (macro_name S) (vect a b))"
+        "@S[a b]"  => "(macrocall (macro_name S) (hcat a b))"
+        "@S[a; b]" => "(macrocall (macro_name S) (vcat a b))"
+        "A.@S[a]"  =>  "(macrocall (. A (macro_name S)) (vect a))"
+        "@S[a].b"  =>  "(. (macrocall (macro_name S) (vect a)) b)"
+        ((v=v"1.7",), "@S[a ;; b]")  =>  "(macrocall (macro_name S) (ncat-2 a b))"
+        ((v=v"1.6",), "@S[a ;; b]")  =>  "(macrocall (macro_name S) (error (ncat-2 a b)))"
         "a[i]"  =>  "(ref a i)"
         "a [i]"  =>  "(ref a (error-t) i)"
         "a[i,j]"  =>  "(ref a i j)"
@@ -419,10 +419,10 @@ tests = [
 
         # Dotted forms
         # Allow `@` in macrocall only in first and last position
-        "A.B.@x"    =>  "(macrocall (. (. A B) @x))"
-        "@A.B.x"    =>  "(macrocall (. (. A B) @x))"
-        "A.@B.x"    =>  "(macrocall (. (. A B) (error-t) @x))"
-        "@M.(x)"    =>  "(macrocall (dotcall @M (error-t) x))"
+        "A.B.@x"    =>  "(macrocall (. (. A B) (macro_name x)))"
+        "@A.B.x"    =>  "(macrocall (macro_name (. (. A B) x)))"
+        "A.@B.x"    =>  "(macrocall (macro_name (. (. A B) (error-t) x)))"
+        "@M.(x)"    =>  "(macrocall (dotcall (macro_name M) (error-t) x))"
         "f.(a,b)"   =>  "(dotcall f a b)"
         "f.(a,b,)"  =>  "(dotcall-, f a b)"
         "f.(a=1; b=2)" => "(dotcall f (= a 1) (parameters (= b 2)))"
@@ -434,11 +434,11 @@ tests = [
         "A.: +"     =>  "(. A (quote-: (error-t) +))"
         "f.\$x"     =>  "(. f (\$ x))"
         "f.\$(x+y)" =>  "(. f (\$ (parens (call-i x + y))))"
-        "A.\$B.@x"  =>  "(macrocall (. (. A (\$ B)) @x))"
-        "@A.\$x a"  =>  "(macrocall (. A (error x)) a)"
-        "A.@x"      =>  "(macrocall (. A @x))"
-        "A.@x a"    =>  "(macrocall (. A @x) a)"
-        "@A.B.@x a" =>  "(macrocall (. (. A B) (error-t) @x) a)"
+        "A.\$B.@x"  =>  "(macrocall (. (. A (\$ B)) (macro_name x)))"
+        "@A.\$x a"  =>  "(macrocall (macro_name (. A (error x))) a)"
+        "A.@x"      =>  "(macrocall (. A (macro_name x)))"
+        "A.@x a"    =>  "(macrocall (. A (macro_name x)) a)"
+        "@A.B.@x a" =>  "(macrocall (macro_name (. (. A B) (error-t) x)) a)"
         # .' discontinued
         "f.'"    =>  "(dotcall-post f (error '))"
         # Field/property syntax
@@ -451,35 +451,35 @@ tests = [
         "f'ᵀ" => "(call-post f 'ᵀ)"
         # Curly calls
         "S {a}"   => "(curly S (error-t) a)"
-        "A.@S{a}" => "(macrocall (. A @S) (braces a))"
-        "@S{a,b}" => "(macrocall @S (braces a b))"
-        "A.@S{a}" => "(macrocall (. A @S) (braces a))"
-        "@S{a}.b" => "(. (macrocall @S (braces a)) b)"
+        "A.@S{a}" => "(macrocall (. A (macro_name S)) (braces a))"
+        "@S{a,b}" => "(macrocall (macro_name S) (braces a b))"
+        "A.@S{a}" => "(macrocall (. A (macro_name S)) (braces a))"
+        "@S{a}.b" => "(. (macrocall (macro_name S) (braces a)) b)"
         "S{a,b}"  => "(curly S a b)"
         "T{y for x = xs; a}" => "(curly T (generator y (iteration (in x xs))) (parameters a))"
         # String macros
-        "x\"str\""   => """(macrocall @x_str (string-r "str"))"""
-        "x`str`"     => """(macrocall @x_cmd (cmdstring-r "str"))"""
-        "x\"\""      => """(macrocall @x_str (string-r ""))"""
-        "x``"        => """(macrocall @x_cmd (cmdstring-r ""))"""
-        "in\"str\""  => """(macrocall @in_str (string-r "str"))"""
-        "outer\"str\"" => """(macrocall @outer_str (string-r "str"))"""
+        "x\"str\""   => """(macrocall (macro_name_str x) (string-r "str"))"""
+        "x`str`"     => """(macrocall (macro_name_cmd x) (cmdstring-r "str"))"""
+        "x\"\""      => """(macrocall (macro_name_str x) (string-r ""))"""
+        "x``"        => """(macrocall (macro_name_cmd x) (cmdstring-r ""))"""
+        "in\"str\""  => """(macrocall (macro_name_str in) (string-r "str"))"""
+        "outer\"str\"" => """(macrocall (macro_name_str outer) (string-r "str"))"""
         # Triple quoted processing for custom strings
-        "r\"\"\"\nx\"\"\""        => raw"""(macrocall @r_str (string-s-r "x"))"""
-        "r\"\"\"\n x\n y\"\"\""   => raw"""(macrocall @r_str (string-s-r "x\n" "y"))"""
-        "r\"\"\"\n x\\\n y\"\"\"" => raw"""(macrocall @r_str (string-s-r "x\\\n" "y"))"""
+        "r\"\"\"\nx\"\"\""        => raw"""(macrocall (macro_name_str r) (string-s-r "x"))"""
+        "r\"\"\"\n x\n y\"\"\""   => raw"""(macrocall (macro_name_str r) (string-s-r "x\n" "y"))"""
+        "r\"\"\"\n x\\\n y\"\"\"" => raw"""(macrocall (macro_name_str r) (string-s-r "x\\\n" "y"))"""
         # Macro suffixes can include keywords and numbers
-        "x\"s\"y"    => """(macrocall @x_str (string-r "s") "y")"""
-        "x\"s\"end"  => """(macrocall @x_str (string-r "s") "end")"""
-        "x\"s\"in"   => """(macrocall @x_str (string-r "s") "in")"""
-        "x\"s\"2"    => """(macrocall @x_str (string-r "s") 2)"""
-        "x\"s\"10.0" => """(macrocall @x_str (string-r "s") 10.0)"""
+        "x\"s\"y"    => """(macrocall (macro_name_str x) (string-r "s") "y")"""
+        "x\"s\"end"  => """(macrocall (macro_name_str x) (string-r "s") "end")"""
+        "x\"s\"in"   => """(macrocall (macro_name_str x) (string-r "s") "in")"""
+        "x\"s\"2"    => """(macrocall (macro_name_str x) (string-r "s") 2)"""
+        "x\"s\"10.0" => """(macrocall (macro_name_str x) (string-r "s") 10.0)"""
         # Cmd macro suffixes
-        "x`s`y"    => """(macrocall @x_cmd (cmdstring-r "s") "y")"""
-        "x`s`end"  => """(macrocall @x_cmd (cmdstring-r "s") "end")"""
-        "x`s`in"   => """(macrocall @x_cmd (cmdstring-r "s") "in")"""
-        "x`s`2"    => """(macrocall @x_cmd (cmdstring-r "s") 2)"""
-        "x`s`10.0" => """(macrocall @x_cmd (cmdstring-r "s") 10.0)"""
+        "x`s`y"    => """(macrocall (macro_name_cmd x) (cmdstring-r "s") "y")"""
+        "x`s`end"  => """(macrocall (macro_name_cmd x) (cmdstring-r "s") "end")"""
+        "x`s`in"   => """(macrocall (macro_name_cmd x) (cmdstring-r "s") "in")"""
+        "x`s`2"    => """(macrocall (macro_name_cmd x) (cmdstring-r "s") 2)"""
+        "x`s`10.0" => """(macrocall (macro_name_cmd x) (cmdstring-r "s") 10.0)"""
     ],
     JuliaSyntax.parse_resword => [
         # In normal_context
@@ -545,9 +545,9 @@ tests = [
         """module A \n "x"\na\n end""" => """(module A (block (doc (string "x") a)))"""
         # export
         "export a"   =>  "(export a)"
-        "export @a"  =>  "(export @a)"
-        "export @var\"'\"" =>  "(export (var @'))"
-        "export a, \n @b"  =>  "(export a @b)"
+        "export @a"  =>  "(export (macro_name a))"
+        "export @var\"'\"" =>  "(export (macro_name (var ')))"
+        "export a, \n @b"  =>  "(export a (macro_name b))"
         "export +, =="     =>  "(export + ==)"
         "export \n a"      =>  "(export a)"
         "export \$a, \$(a*b)"  =>  "(export (\$ a) (\$ (parens (call-i a * b))))"
@@ -601,9 +601,9 @@ tests = [
         "function (x=1) end"   =>  "(function (tuple-p (= x 1)) (block))"
         "function (;x=1) end"  =>  "(function (tuple-p (parameters (= x 1))) (block))"
         "function (f(x),) end" =>  "(function (tuple-p-, (call f x)) (block))"
-        "function (@f(x);) end" => "(function (tuple-p (macrocall-p @f x) (parameters)) (block))"
-        "function (@f(x)...) end" =>  "(function (tuple-p (... (macrocall-p @f x))) (block))"
-        "function (@f(x)) end" =>  "(function (error (tuple-p (macrocall-p @f x))) (block))"
+        "function (@f(x);) end" => "(function (tuple-p (macrocall-p (macro_name f) x) (parameters)) (block))"
+        "function (@f(x)...) end" =>  "(function (tuple-p (... (macrocall-p (macro_name f) x))) (block))"
+        "function (@f(x)) end" =>  "(function (error (tuple-p (macrocall-p (macro_name f) x))) (block))"
         "function (\$f) end"   =>  "(function (error (tuple-p (\$ f))) (block))"
         "function ()(x) end"   =>  "(function (call (tuple-p) x) (block))"
         "function (A).f() end" =>  "(function (call (. (parens A) f)) (block))"
@@ -647,10 +647,10 @@ tests = [
         "function f() \n a \n b end"  =>  "(function (call f) (block a b))"
         "function f() end"       =>  "(function (call f) (block))"
         # Macrocall as sig
-        ((v=v"1.12",), "function @callmemacro(a::Int) \n 1 \n end") => "(function (macrocall-p @callmemacro (::-i a Int)) (block 1))"
-        ((v=v"1.12",), "function @callmemacro(a::T, b::T) where T <: Int64\n3\nend") => "(function (where (macrocall-p @callmemacro (::-i a T) (::-i b T)) (<: T Int64)) (block 3))"
-        ((v=v"1.12",), "function @callmemacro(a::Int, b::Int, c::Int)::Float64\n4\nend") => "(function (::-i (macrocall-p @callmemacro (::-i a Int) (::-i b Int) (::-i c Int)) Float64) (block 4))"
-        ((v=v"1.12",), "function @f()() end") => "(function (call (macrocall-p @f)) (block))"
+        ((v=v"1.12",), "function @callmemacro(a::Int) \n 1 \n end") => "(function (macrocall-p (macro_name callmemacro) (::-i a Int)) (block 1))"
+        ((v=v"1.12",), "function @callmemacro(a::T, b::T) where T <: Int64\n3\nend") => "(function (where (macrocall-p (macro_name callmemacro) (::-i a T) (::-i b T)) (<: T Int64)) (block 3))"
+        ((v=v"1.12",), "function @callmemacro(a::Int, b::Int, c::Int)::Float64\n4\nend") => "(function (::-i (macrocall-p (macro_name callmemacro) (::-i a Int) (::-i b Int) (::-i c Int)) Float64) (block 4))"
+        ((v=v"1.12",), "function @f()() end") => "(function (call (macrocall-p (macro_name f))) (block))"
         # Errors
         "function"            => "(function (error (error)) (block (error)) (error-t))"
     ],
@@ -704,9 +704,9 @@ tests = [
         # Modules with operator symbol names
         "import .⋆"     =>  "(import (importpath . ⋆))"
         # Expressions allowed in import paths
-        "import @x"     =>  "(import (importpath @x))"
+        "import @x"     =>  "(import (importpath (macro_name x)))"
         "import \$A"    =>  "(import (importpath (\$ A)))"
-        "import \$A.@x" =>  "(import (importpath (\$ A) @x))"
+        "import \$A.@x" =>  "(import (importpath (\$ A) (macro_name x)))"
         "import A.B"    =>  "(import (importpath A B))"
         "import A.B.C"  =>  "(import (importpath A B C))"
         "import A.:+"   =>  "(import (importpath A (quote-: +)))"
@@ -893,9 +893,9 @@ tests = [
         ((v=v"1.7",), "{a ;; b}") =>  "(bracescat (nrow-2 a b))"
         ((v=v"1.7",), "{a ;;;; b}") =>  "(bracescat (nrow-4 a b))"
         # Macro names can be keywords
-        "@end x" => "(macrocall @end x)"
+        "@end x" => "(macrocall (macro_name end) x)"
         # __dot__ macro
-        "@. x" => "(macrocall @. x)"
+        "@. x" => "(macrocall (macro_name .) x)"
         # cmd strings
         "``"         =>  "(cmdstring-r \"\")"
         "`cmd`"      =>  "(cmdstring-r \"cmd\")"
@@ -1047,8 +1047,8 @@ tests = [
         "public export=true foo, bar"                   => PARSE_ERROR # but these may be
         "public experimental=true foo, bar"             => PARSE_ERROR # supported soon ;)
         "public(x::String) = false"                     => "(function-= (call public (::-i x String)) false)"
-        "module M; export @a; end"                      => "(module M (block (export @a)))"
-        "module M; public @a; end"                      => "(module M (block (public @a)))"
+        "module M; export @a; end"                      => "(module M (block (export (macro_name a))))"
+        "module M; public @a; end"                      => "(module M (block (public (macro_name a))))"
         "module M; export ⤈; end"                       => "(module M (block (export ⤈)))"
         "module M; public ⤈; end"                       => "(module M (block (public ⤈)))"
         "public = 4"                                    => "(= public 4)"
@@ -1056,7 +1056,7 @@ tests = [
         "public() = 6"                                  => "(function-= (call public) 6)"
     ]),
     JuliaSyntax.parse_stmts => [
-        ((v = v"1.12",), "@callmemacro(b::Float64) = 2") => "(= (macrocall-p @callmemacro (::-i b Float64)) 2)"
+        ((v = v"1.12",), "@callmemacro(b::Float64) = 2") => "(= (macrocall-p (macro_name callmemacro) (::-i b Float64)) 2)"
     ],
     JuliaSyntax.parse_docstring => [
         """ "notdoc" ]        """ => "(string \"notdoc\")"
@@ -1098,10 +1098,10 @@ parsestmt_test_specs = [
 
     # The following may not be ideal error recovery! But at least the parser
     # shouldn't crash
-    "@(x y)" => "(macrocall (parens @x (error-t y)))"
+    "@(x y)" => "(macrocall (macro_name (parens x (error-t y))))"
     "|(&\nfunction" => "(call | (& (function (error (error)) (block (error)) (error-t))) (error-t))"
-    "@(" => "(macrocall (parens (error-t)))"
-    "x = @(" => "(= x (macrocall (parens (error-t))))"
+    "@(" => "(macrocall (macro_name (parens (error-t))))"
+    "x = @(" => "(= x (macrocall (macro_name (parens (error-t)))))"
     "function(where" => "(function (tuple-p where (error-t)) (block (error)) (error-t))"
     # Contextual keyword pairs must not be separated by newlines even within parens
     "(abstract\ntype X end)" => "(wrapper (parens abstract (error-t type X)) (error-t end ✘))"
@@ -1189,9 +1189,9 @@ end
 @testset "Unicode normalization in tree conversion" begin
     # ɛµ normalizes to εμ
     @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "\u025B\u00B5()") == "(call \u03B5\u03BC)"
-    @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "@\u025B\u00B5") == "(macrocall @\u03B5\u03BC)"
-    @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "\u025B\u00B5\"\"") == "(macrocall @\u03B5\u03BC_str (string-r \"\"))"
-    @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "\u025B\u00B5``") == "(macrocall @\u03B5\u03BC_cmd (cmdstring-r \"\"))"
+    @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "@\u025B\u00B5") == "(macrocall (macro_name \u03B5\u03BC))"
+    @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "\u025B\u00B5\"\"") == "(macrocall (macro_name_str \u03B5\u03BC) (string-r \"\"))"
+    @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "\u025B\u00B5``") == "(macrocall (macro_name_cmd \u03B5\u03BC) (cmdstring-r \"\"))"
     # · and · normalize to ⋅
     @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "a \u00B7 b") == "(call-i a \u22C5 b)"
     @test parse_to_sexpr_str(JuliaSyntax.parse_eq, "a \u0387 b") == "(call-i a \u22C5 b)"

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -421,7 +421,7 @@ tests = [
         # Allow `@` in macrocall only in first and last position
         "A.B.@x"    =>  "(macrocall (. (. A B) (macro_name x)))"
         "@A.B.x"    =>  "(macrocall (macro_name (. (. A B) x)))"
-        "A.@B.x"    =>  "(macrocall (macro_name (. (. A B) (error-t) x)))"
+        "A.@B.x"    =>  "(macrocall (. (. A (error-t) B) (macro_name (error-t) x)))"
         "@M.(x)"    =>  "(macrocall (dotcall (macro_name M) (error-t) x))"
         "f.(a,b)"   =>  "(dotcall f a b)"
         "f.(a,b,)"  =>  "(dotcall-, f a b)"


### PR DESCRIPTION
The current representation for macro names is a bit peculiar. When the parser encounters `@a`, it treats `@` as notation for the macrocall and then `reset_node!`'s (which itself may be considerd a bit of a code smell) the `a` to a special MacroName token kind that (when translated back to julia Expr) implicitly adds back the `@`. Things get even more preculiar with `@var"a"` where only the token inside the string macro gets reset.

One particular consequence of this is https://github.com/JuliaLang/julia/issues/58885, because our translation back to Expr does not check the RAW_STRING_FLAG (whereas the translation for K"Identifier" does).

A second issue is that we currently parse `@A.b.c` and `A.b.@c` to the same SyntaxTree (of course the green tree is different). We aren't currently being super precise about the required invariants for syntax trees, but in general it would be desirable for non-trivia notation (like `@`) to be precisely recoverable from the tree, which is not the case here. This is especially annoying because there are syntax cases that are errors for one of these, but not the other (e.g. `@A.b.$` is an error, but `A.B.@$` is allowed). Now, I think the wisdom of some of those syntax choices can be debated, but that is the situation we face.

So this PR tries to clean that all up a bit by:
- Replacing the terminal K"MacroName" by a non-terminal K"macro_name". With this form, `@A.c` parses as `(macro_name (. A c))` while `A.@c` parses as `(. A (macro_name c))`.
- (In particular the `@` notation is now always associated with the macro_name).
- Emitting the dots in `@..` and `@...` as direct identifier tokens rather than having to reset them back.
- Adjusting everything else accordingly.

Partially written by Claude Code, though it had some trouble with the actual code changes.