### PR TITLE
Remove separate syntax heads for each operator

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -101,7 +101,6 @@ JuliaSyntax.is_infix_op_call
 JuliaSyntax.is_prefix_op_call
 JuliaSyntax.is_postfix_op_call
 JuliaSyntax.is_dotted
-JuliaSyntax.is_suffixed
 JuliaSyntax.is_decorated
 JuliaSyntax.numeric_flags
 ```

--- a/src/JuliaSyntax.jl
+++ b/src/JuliaSyntax.jl
@@ -41,7 +41,11 @@ export SourceFile
 @_public source_line_range
 
 # Expression predicates, kinds and flags
-export @K_str, kind
+export @K_str, kind, PrecedenceLevel, PREC_NONE, PREC_ASSIGNMENT,
+    PREC_PAIRARROW, PREC_CONDITIONAL, PREC_ARROW, PREC_LAZYOR, PREC_LAZYAND,
+    PREC_COMPARISON, PREC_PIPE_LT, PREC_PIPE_GT, PREC_COLON, PREC_PLUS,
+    PREC_BITSHIFT, PREC_TIMES, PREC_RATIONAL, PREC_POWER, PREC_DECL,
+    PREC_WHERE, PREC_DOT, PREC_QUOTE, PREC_UNICODE_OPS, PREC_COMPOUND_ASSIGN, generic_operators_by_level
 @_public Kind
 
 @_public flags,
@@ -53,7 +57,6 @@ export @K_str, kind
     is_prefix_op_call,
     is_postfix_op_call,
     is_dotted,
-    is_suffixed,
     is_decorated,
     numeric_flags,
     has_flags,

--- a/src/core/parse_stream.jl
+++ b/src/core/parse_stream.jl
@@ -45,7 +45,7 @@ kind(head::SyntaxHead) = head.kind
 
 Return the flag bits of a syntactic construct. Prefer to query these with the
 predicates `is_trivia`, `is_prefix_call`, `is_infix_op_call`,
-`is_prefix_op_call`, `is_postfix_op_call`, `is_dotted`, `is_suffixed`,
+`is_prefix_op_call`, `is_postfix_op_call`, `is_dotted`,
 `is_decorated`.
 
 Or extract numeric portion of the flags with `numeric_flags`.
@@ -376,7 +376,10 @@ function _buffer_lookahead_tokens(lexer, lookahead)
         was_whitespace = is_whitespace(k)
         had_whitespace |= was_whitespace
         f = EMPTY_FLAGS
-        raw.suffix     && (f |= SUFFIXED_FLAG)
+        if k == K"Operator" && raw.op_precedence != Tokenize.PREC_NONE
+            # Store operator precedence in numeric flags
+            f |= set_numeric_flags(Int(raw.op_precedence))
+        end
         push!(lookahead, SyntaxToken(SyntaxHead(k, f), k,
                                      had_whitespace, raw.endbyte + 2))
         token_count += 1

--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -338,6 +338,9 @@ end
         return adjust_macro_name!(retexpr.args[1], k)
     elseif k == K"?"
         retexpr.head = :if
+    elseif k == K"dots"
+        n = numeric_flags(flags(nodehead))
+        return n == 2 ? :(..) : :(...)
     elseif k == K"op=" && length(args) == 3
         lhs = args[1]
         op = args[2]

--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -341,20 +341,28 @@ end
     elseif k == K"dots"
         n = numeric_flags(flags(nodehead))
         return n == 2 ? :(..) : :(...)
-    elseif k == K"op=" && length(args) == 3
-        lhs = args[1]
-        op = args[2]
-        rhs = args[3]
-        headstr = string(args[2], '=')
-        retexpr.head = Symbol(headstr)
-        retexpr.args = Any[lhs, rhs]
-    elseif k == K".op=" && length(args) == 3
-        lhs = args[1]
-        op = args[2]
-        rhs = args[3]
-        headstr = '.' * string(args[2], '=')
-        retexpr.head = Symbol(headstr)
-        retexpr.args = Any[lhs, rhs]
+    elseif k == K"op="
+        if length(args) == 3
+            lhs = args[1]
+            op = args[2]
+            rhs = args[3]
+            headstr = string(args[2], '=')
+            retexpr.head = Symbol(headstr)
+            retexpr.args = Any[lhs, rhs]
+        elseif length(args) == 1
+            return Symbol(string(args[1], '='))
+        end
+    elseif k == K".op="
+        if length(args) == 3
+            lhs = args[1]
+            op = args[2]
+            rhs = args[3]
+            headstr = '.' * string(args[2], '=')
+            retexpr.head = Symbol(headstr)
+            retexpr.args = Any[lhs, rhs]
+        else
+            return Symbol(string('.', args[1], '='))
+        end
     elseif k == K"macrocall"
         if length(args) >= 2
             a2 = args[2]

--- a/src/julia/kinds.jl
+++ b/src/julia/kinds.jl
@@ -181,7 +181,6 @@ Return the `Kind` of `x`.
 """
 kind(k::Kind) = k
 
-
 #-------------------------------------------------------------------------------
 # Kinds used by JuliaSyntax
 register_kinds!(JuliaSyntax, 0, [
@@ -193,6 +192,7 @@ register_kinds!(JuliaSyntax, 0, [
     # Identifiers
     "BEGIN_IDENTIFIERS"
         "Identifier"
+        "Operator"
         "Placeholder" # Used for empty catch variables, and all-underscore identifiers in lowering
     "END_IDENTIFIERS"
 
@@ -278,725 +278,56 @@ register_kinds!(JuliaSyntax, 0, [
     "ErrorInvalidOperator"
     "Error**"
 
-    # Level 1
+    # Various operators that have special parsing rules and thus get explicit heads.
+    # All other operators (including suffixed versions of these) are K"Operator".
     "BEGIN_ASSIGNMENTS"
-        "BEGIN_SYNTACTIC_ASSIGNMENTS"
         "="
         ".="
-        "op="  # Updating assignment operator ( $= %= &= *= += -= //= /= <<= >>= >>>= \= ^= |= ÷= ⊻= )
-        ".op="
         ":="
-        "END_SYNTACTIC_ASSIGNMENTS"
         "~"
         "≔"
         "⩴"
         "≕"
+        # Compound assignments
+        "op="
+        ".op="
     "END_ASSIGNMENTS"
-
-    "BEGIN_PAIRARROW"
-        "=>"
-    "END_PAIRARROW"
-
-    # Level 2
-    "BEGIN_CONDITIONAL"
-    "?"
-    "END_CONDITIONAL"
-
-    # Level 3
-    "BEGIN_ARROW"
-        "-->"
-        "<--"
-        "<-->"
-        "←"
-        "→"
-        "↔"
-        "↚"
-        "↛"
-        "↞"
-        "↠"
-        "↢"
-        "↣"
-        "↤"
-        "↦"
-        "↮"
-        "⇎"
-        "⇍"
-        "⇏"
-        "⇐"
-        "⇒"
-        "⇔"
-        "⇴"
-        "⇶"
-        "⇷"
-        "⇸"
-        "⇹"
-        "⇺"
-        "⇻"
-        "⇼"
-        "⇽"
-        "⇾"
-        "⇿"
-        "⟵"
-        "⟶"
-        "⟷"
-        "⟹"
-        "⟺"
-        "⟻"
-        "⟼"
-        "⟽"
-        "⟾"
-        "⟿"
-        "⤀"
-        "⤁"
-        "⤂"
-        "⤃"
-        "⤄"
-        "⤅"
-        "⤆"
-        "⤇"
-        "⤌"
-        "⤍"
-        "⤎"
-        "⤏"
-        "⤐"
-        "⤑"
-        "⤔"
-        "⤕"
-        "⤖"
-        "⤗"
-        "⤘"
-        "⤝"
-        "⤞"
-        "⤟"
-        "⤠"
-        "⥄"
-        "⥅"
-        "⥆"
-        "⥇"
-        "⥈"
-        "⥊"
-        "⥋"
-        "⥎"
-        "⥐"
-        "⥒"
-        "⥓"
-        "⥖"
-        "⥗"
-        "⥚"
-        "⥛"
-        "⥞"
-        "⥟"
-        "⥢"
-        "⥤"
-        "⥦"
-        "⥧"
-        "⥨"
-        "⥩"
-        "⥪"
-        "⥫"
-        "⥬"
-        "⥭"
-        "⥰"
-        "⧴"
-        "⬱"
-        "⬰"
-        "⬲"
-        "⬳"
-        "⬴"
-        "⬵"
-        "⬶"
-        "⬷"
-        "⬸"
-        "⬹"
-        "⬺"
-        "⬻"
-        "⬼"
-        "⬽"
-        "⬾"
-        "⬿"
-        "⭀"
-        "⭁"
-        "⭂"
-        "⭃"
-        "⥷"
-        "⭄"
-        "⥺"
-        "⭇"
-        "⭈"
-        "⭉"
-        "⭊"
-        "⭋"
-        "⭌"
-        "￩"
-        "￫"
-        "⇜"
-        "⇝"
-        "↜"
-        "↝"
-        "↩"
-        "↪"
-        "↫"
-        "↬"
-        "↼"
-        "↽"
-        "⇀"
-        "⇁"
-        "⇄"
-        "⇆"
-        "⇇"
-        "⇉"
-        "⇋"
-        "⇌"
-        "⇚"
-        "⇛"
-        "⇠"
-        "⇢"
-        "↷"
-        "↶"
-        "↺"
-        "↻"
-        "🢲"
-    "END_ARROW"
-
-    # Level 4
-    "BEGIN_LAZYOR"
-        "||"
-        ".||"
-    "END_LAZYOR"
-
-    # Level 5
-    "BEGIN_LAZYAND"
-        "&&"
-        ".&&"
-    "END_LAZYAND"
-
-    # Level 6
-    "BEGIN_COMPARISON"
-        "<:"
-        ">:"
-        ">"
-        "<"
-        ">="
-        "≥"
-        "<="
-        "≤"
-        "=="
-        "==="
-        "≡"
-        "!="
-        "≠"
-        "!=="
-        "≢"
-        "∈"
-        "in"
-        "isa"
-        "∉"
-        "∋"
-        "∌"
-        "⊆"
-        "⊈"
-        "⊂"
-        "⊄"
-        "⊊"
-        "∝"
-        "∊"
-        "∍"
-        "∥"
-        "∦"
-        "∷"
-        "∺"
-        "∻"
-        "∽"
-        "∾"
-        "≁"
-        "≃"
-        "≂"
-        "≄"
-        "≅"
-        "≆"
-        "≇"
-        "≈"
-        "≉"
-        "≊"
-        "≋"
-        "≌"
-        "≍"
-        "≎"
-        "≐"
-        "≑"
-        "≒"
-        "≓"
-        "≖"
-        "≗"
-        "≘"
-        "≙"
-        "≚"
-        "≛"
-        "≜"
-        "≝"
-        "≞"
-        "≟"
-        "≣"
-        "≦"
-        "≧"
-        "≨"
-        "≩"
-        "≪"
-        "≫"
-        "≬"
-        "≭"
-        "≮"
-        "≯"
-        "≰"
-        "≱"
-        "≲"
-        "≳"
-        "≴"
-        "≵"
-        "≶"
-        "≷"
-        "≸"
-        "≹"
-        "≺"
-        "≻"
-        "≼"
-        "≽"
-        "≾"
-        "≿"
-        "⊀"
-        "⊁"
-        "⊃"
-        "⊅"
-        "⊇"
-        "⊉"
-        "⊋"
-        "⊏"
-        "⊐"
-        "⊑"
-        "⊒"
-        "⊜"
-        "⊩"
-        "⊬"
-        "⊮"
-        "⊰"
-        "⊱"
-        "⊲"
-        "⊳"
-        "⊴"
-        "⊵"
-        "⊶"
-        "⊷"
-        "⋍"
-        "⋐"
-        "⋑"
-        "⋕"
-        "⋖"
-        "⋗"
-        "⋘"
-        "⋙"
-        "⋚"
-        "⋛"
-        "⋜"
-        "⋝"
-        "⋞"
-        "⋟"
-        "⋠"
-        "⋡"
-        "⋢"
-        "⋣"
-        "⋤"
-        "⋥"
-        "⋦"
-        "⋧"
-        "⋨"
-        "⋩"
-        "⋪"
-        "⋫"
-        "⋬"
-        "⋭"
-        "⋲"
-        "⋳"
-        "⋴"
-        "⋵"
-        "⋶"
-        "⋷"
-        "⋸"
-        "⋹"
-        "⋺"
-        "⋻"
-        "⋼"
-        "⋽"
-        "⋾"
-        "⋿"
-        "⟈"
-        "⟉"
-        "⟒"
-        "⦷"
-        "⧀"
-        "⧁"
-        "⧡"
-        "⧣"
-        "⧤"
-        "⧥"
-        "⩦"
-        "⩧"
-        "⩪"
-        "⩫"
-        "⩬"
-        "⩭"
-        "⩮"
-        "⩯"
-        "⩰"
-        "⩱"
-        "⩲"
-        "⩳"
-        "⩵"
-        "⩶"
-        "⩷"
-        "⩸"
-        "⩹"
-        "⩺"
-        "⩻"
-        "⩼"
-        "⩽"
-        "⩾"
-        "⩿"
-        "⪀"
-        "⪁"
-        "⪂"
-        "⪃"
-        "⪄"
-        "⪅"
-        "⪆"
-        "⪇"
-        "⪈"
-        "⪉"
-        "⪊"
-        "⪋"
-        "⪌"
-        "⪍"
-        "⪎"
-        "⪏"
-        "⪐"
-        "⪑"
-        "⪒"
-        "⪓"
-        "⪔"
-        "⪕"
-        "⪖"
-        "⪗"
-        "⪘"
-        "⪙"
-        "⪚"
-        "⪛"
-        "⪜"
-        "⪝"
-        "⪞"
-        "⪟"
-        "⪠"
-        "⪡"
-        "⪢"
-        "⪣"
-        "⪤"
-        "⪥"
-        "⪦"
-        "⪧"
-        "⪨"
-        "⪩"
-        "⪪"
-        "⪫"
-        "⪬"
-        "⪭"
-        "⪮"
-        "⪯"
-        "⪰"
-        "⪱"
-        "⪲"
-        "⪳"
-        "⪴"
-        "⪵"
-        "⪶"
-        "⪷"
-        "⪸"
-        "⪹"
-        "⪺"
-        "⪻"
-        "⪼"
-        "⪽"
-        "⪾"
-        "⪿"
-        "⫀"
-        "⫁"
-        "⫂"
-        "⫃"
-        "⫄"
-        "⫅"
-        "⫆"
-        "⫇"
-        "⫈"
-        "⫉"
-        "⫊"
-        "⫋"
-        "⫌"
-        "⫍"
-        "⫎"
-        "⫏"
-        "⫐"
-        "⫑"
-        "⫒"
-        "⫓"
-        "⫔"
-        "⫕"
-        "⫖"
-        "⫗"
-        "⫘"
-        "⫙"
-        "⫷"
-        "⫸"
-        "⫹"
-        "⫺"
-        "⊢"
-        "⊣"
-        "⟂"
-        # ⫪,⫫ see https://github.com/JuliaLang/julia/issues/39350
-        "⫪"
-        "⫫"
-    "END_COMPARISON"
-
-    # Level 7
-    "BEGIN_PIPE"
-        "<|"
-        "|>"
-    "END_PIPE"
-
-    # Level 8
-    "BEGIN_COLON"
-        ":"
-        "…"
-        "⁝"
-        "⋮"
-        "⋱"
-        "⋰"
-        "⋯"
-    "END_COLON"
-
-    # Level 9
-    "BEGIN_PLUS"
-        "\$"
-        "+"
-        "-" # also used for "−"
-        "++"
-        "⊕"
-        "⊖"
-        "⊞"
-        "⊟"
-        "|"
-        "∪"
-        "∨"
-        "⊔"
-        "±"
-        "∓"
-        "∔"
-        "∸"
-        "≏"
-        "⊎"
-        "⊻"
-        "⊽"
-        "⋎"
-        "⋓"
-        "⟇"
-        "⧺"
-        "⧻"
-        "⨈"
-        "⨢"
-        "⨣"
-        "⨤"
-        "⨥"
-        "⨦"
-        "⨧"
-        "⨨"
-        "⨩"
-        "⨪"
-        "⨫"
-        "⨬"
-        "⨭"
-        "⨮"
-        "⨹"
-        "⨺"
-        "⩁"
-        "⩂"
-        "⩅"
-        "⩊"
-        "⩌"
-        "⩏"
-        "⩐"
-        "⩒"
-        "⩔"
-        "⩖"
-        "⩗"
-        "⩛"
-        "⩝"
-        "⩡"
-        "⩢"
-        "⩣"
-        "¦"
-    "END_PLUS"
-
-    # Level 10
-    "BEGIN_TIMES"
-        "*"
-        "/"
-        "÷"
-        "%"
-        "⋅" # also used for lookalikes "·" and "·"
-        "∘"
-        "×"
-        "\\"
-        "&"
-        "∩"
-        "∧"
-        "⊗"
-        "⊘"
-        "⊙"
-        "⊚"
-        "⊛"
-        "⊠"
-        "⊡"
-        "⊓"
-        "∗"
-        "∙"
-        "∤"
-        "⅋"
-        "≀"
-        "⊼"
-        "⋄"
-        "⋆"
-        "⋇"
-        "⋉"
-        "⋊"
-        "⋋"
-        "⋌"
-        "⋏"
-        "⋒"
-        "⟑"
-        "⦸"
-        "⦼"
-        "⦾"
-        "⦿"
-        "⧶"
-        "⧷"
-        "⨇"
-        "⨰"
-        "⨱"
-        "⨲"
-        "⨳"
-        "⨴"
-        "⨵"
-        "⨶"
-        "⨷"
-        "⨸"
-        "⨻"
-        "⨼"
-        "⨽"
-        "⩀"
-        "⩃"
-        "⩄"
-        "⩋"
-        "⩍"
-        "⩎"
-        "⩑"
-        "⩓"
-        "⩕"
-        "⩘"
-        "⩚"
-        "⩜"
-        "⩞"
-        "⩟"
-        "⩠"
-        "⫛"
-        "⊍"
-        "▷"
-        "⨝"
-        "⟕"
-        "⟖"
-        "⟗"
-        "⌿"
-        "⨟"
-    "END_TIMES"
-
-    # Level 11
-    "BEGIN_RATIONAL"
-        "//"
-    "END_RATIONAL"
-
-    # Level 12
-    "BEGIN_BITSHIFTS"
-        "<<"
-        ">>"
-        ">>>"
-    "END_BITSHIFTS"
-
-    # Level 13
-    "BEGIN_POWER"
-        "^"
-        "↑"
-        "↓"
-        "⇵"
-        "⟰"
-        "⟱"
-        "⤈"
-        "⤉"
-        "⤊"
-        "⤋"
-        "⤒"
-        "⤓"
-        "⥉"
-        "⥌"
-        "⥍"
-        "⥏"
-        "⥑"
-        "⥔"
-        "⥕"
-        "⥘"
-        "⥙"
-        "⥜"
-        "⥝"
-        "⥠"
-        "⥡"
-        "⥣"
-        "⥥"
-        "⥮"
-        "⥯"
-        "￪"
-        "￬"
-    "END_POWER"
-
-    # Level 14
-    "BEGIN_DECL"
-        "::"
-    "END_DECL"
-
-    # Level 15
-    "BEGIN_WHERE"
-        "where"
-    "END_WHERE"
-
-    # Level 16
-    "BEGIN_DOT"
-        "."
-    "END_DOT"
-
-    "!"
-    "'"
-    ".'"
-    "->"
-
-    "BEGIN_UNICODE_OPS"
-        "¬"
-        "√"
-        "∛"
-        "∜"
-    "END_UNICODE_OPS"
+    "?"     # ternary operator
+    "||"    # not an operator call
+    ".||"   # dotted of above (not emitted by lexer)
+    "&&"    # not an operator call
+    ".&&"   # dotted of above (not emitted by lexer)
+    "<:"    # subtype syntax
+    ">:"    # supertype syntax
+    "::"    # field type syntax
+    "."     # various dot syntax
+    ".."    # .. operator (not emitted by lexer)
+    "in"    # iteration syntax
+    "isa"
+    "where"
+    "!"     # syntactic unary
+    "'"     # special postfix parsing
+    ".'"    # special postfix parsing
+    "->"    # syntactic arrow
+    "-->"   # syntactic arrow
+    ":"     # used for quoting
+    "+"     # used in numeric constants
+    "++"    # special chaining syntax
+    "*"     # special chaining syntax
+    "<"     # recovery path for :<
+    ">"     # recovery path for :>
+    "\$"    # interpolation
+    "-"     # negated constants
+    "&"     # syntactic unary
+    "∈"     # iteration syntax
+    # all syntactic unary
+    "⋆"
+    "±"
+    "∓"
+    "¬"
+    "√"
+    "∛"
+    "∜"
     "END_OPS"
 
     # 2. Nonterminals which are exposed in the AST, but where the surface
@@ -1073,6 +404,109 @@ register_kinds!(JuliaSyntax, 0, [
         "error"
     "END_ERRORS"
 ])
+
+@enum PrecedenceLevel begin
+    PREC_NONE
+    PREC_ASSIGNMENT
+    PREC_PAIRARROW
+    PREC_CONDITIONAL
+    PREC_ARROW
+    PREC_LAZYOR
+    PREC_LAZYAND
+    PREC_COMPARISON
+    PREC_PIPE_LT
+    PREC_PIPE_GT
+    PREC_COLON
+    PREC_PLUS
+    PREC_BITSHIFT
+    PREC_TIMES
+    PREC_RATIONAL
+    PREC_POWER
+    PREC_DECL
+    PREC_WHERE
+    PREC_DOT
+    PREC_QUOTE
+    PREC_UNICODE_OPS
+    # Special precendence to only allow compound assignment for designated operators, for
+    # compatibility with flisp
+    PREC_COMPOUND_ASSIGN
+end
+
+const generic_operators_by_level = Dict{PrecedenceLevel, Vector{Char}}(
+    PREC_ASSIGNMENT  => Char[#= = .= := ~ ≔ ⩴ ≕ =#],
+    PREC_PAIRARROW   => Char[#= => =#],
+    PREC_CONDITIONAL => Char[#= ? =#],
+    PREC_ARROW =>
+         [#=  -> --> <-- <--> =#
+          '←', '→', '↔', '↚', '↛', '↞', '↠', '↢',
+          '↣', '↤', '↦', '↮', '⇎', '⇍', '⇏', '⇐', '⇒', '⇔', '⇴',
+          '⇶', '⇷', '⇸', '⇹', '⇺', '⇻', '⇼', '⇽', '⇾', '⇿', '⟵',
+          '⟶', '⟷', '⟹', '⟺', '⟻', '⟼', '⟽', '⟾', '⟿', '⤀', '⤁',
+          '⤂', '⤃', '⤄', '⤅', '⤆', '⤇', '⤌', '⤍', '⤎', '⤏', '⤐', '⤑',
+          '⤔', '⤕', '⤖', '⤗', '⤘', '⤝', '⤞', '⤟', '⤠', '⥄', '⥅', '⥆',
+          '⥇', '⥈', '⥊', '⥋', '⥎', '⥐', '⥒', '⥓', '⥖', '⥗', '⥚', '⥛',
+          '⥞', '⥟', '⥢', '⥤', '⥦', '⥧', '⥨', '⥩', '⥪', '⥫', '⥬', '⥭',
+          '⥰', '⧴', '⬱', '⬰', '⬲', '⬳', '⬴', '⬵', '⬶', '⬷', '⬸', '⬹',
+          '⬺', '⬻', '⬼', '⬽', '⬾', '⬿', '⭀', '⭁', '⭂', '⭃', '⥷', '⭄',
+          '⥺', '⭇', '⭈', '⭉', '⭊', '⭋', '⭌', '￩', '￫', '⇜', '⇝', '↜', '↝',
+          '↩', '↪', '↫', '↬', '↼', '↽', '⇀', '⇁', '⇄', '⇆', '⇇', '⇉', '⇋',
+          '⇌', '⇚', '⇛', '⇠', '⇢', '↷', '↶', '↺', '↻', '🢲'],
+    PREC_LAZYOR  => Char[#= || =#],
+    PREC_LAZYAND => Char[#= && =#],
+    PREC_COMPARISON =>
+         [#= <: >: in isa < > ∈ == != !== =#
+          '≥',  '≤', '≡', '≠', '≢', '∉', '∋',
+          '∌', '⊆', '⊈', '⊂', '⊄', '⊊', '∝', '∊', '∍', '∥', '∦',
+          '∷', '∺', '∻', '∽', '∾', '≁', '≃', '≂', '≄', '≅', '≆',
+          '≇', '≈', '≉', '≊', '≋', '≌', '≍', '≎', '≐', '≑', '≒',
+          '≓', '≖', '≗', '≘', '≙', '≚', '≛', '≜', '≝', '≞', '≟',
+          '≣', '≦', '≧', '≨', '≩', '≪', '≫', '≬', '≭', '≮', '≯',
+          '≰', '≱', '≲', '≳', '≴', '≵', '≶', '≷', '≸', '≹', '≺',
+          '≻', '≼', '≽', '≾', '≿', '⊀', '⊁', '⊃', '⊅', '⊇', '⊉',
+          '⊋', '⊏', '⊐', '⊑', '⊒', '⊜', '⊩', '⊬', '⊮', '⊰', '⊱',
+          '⊲', '⊳', '⊴', '⊵', '⊶', '⊷', '⋍', '⋐', '⋑', '⋕', '⋖',
+          '⋗', '⋘', '⋙', '⋚', '⋛', '⋜', '⋝', '⋞', '⋟', '⋠', '⋡',
+          '⋢', '⋣', '⋤', '⋥', '⋦', '⋧', '⋨', '⋩', '⋪', '⋫', '⋬',
+          '⋭', '⋲', '⋳', '⋴', '⋵', '⋶', '⋷', '⋸', '⋹', '⋺', '⋻',
+          '⋼', '⋽', '⋾', '⋿', '⟈', '⟉', '⟒', '⦷', '⧀', '⧁', '⧡',
+          '⧣', '⧤', '⧥', '⩦', '⩧', '⩪', '⩫', '⩬', '⩭', '⩮', '⩯',
+          '⩰', '⩱', '⩲', '⩳', '⩵', '⩶', '⩷', '⩸', '⩹', '⩺', '⩻',
+          '⩼', '⩽', '⩾', '⩿', '⪀', '⪁', '⪂', '⪃', '⪄', '⪅', '⪆', '⪇',
+          '⪈', '⪉', '⪊', '⪋', '⪌', '⪍', '⪎', '⪏', '⪐', '⪑', '⪒', '⪓',
+          '⪔', '⪕', '⪖', '⪗', '⪘', '⪙', '⪚', '⪛', '⪜', '⪝', '⪞', '⪟',
+          '⪠', '⪡', '⪢', '⪣', '⪤', '⪥', '⪦', '⪧', '⪨', '⪩', '⪪',
+          '⪫', '⪬', '⪭', '⪮', '⪯', '⪰', '⪱', '⪲', '⪳', '⪴', '⪵',
+          '⪶', '⪷', '⪸', '⪹', '⪺', '⪻', '⪼', '⪽', '⪾', '⪿', '⫀',
+          '⫁', '⫂', '⫃', '⫄', '⫅', '⫆', '⫇', '⫈', '⫉', '⫊', '⫋',
+          '⫌', '⫍', '⫎', '⫏', '⫐', '⫑', '⫒', '⫓', '⫔', '⫕', '⫖',
+          '⫗', '⫘', '⫙', '⫷', '⫸', '⫹', '⫺', '⊢', '⊣', '⟂', '⫪', '⫫'],
+    PREC_PIPE_LT => Char[#= <| =#],
+    PREC_PIPE_GT => Char[#= |> =#],
+    PREC_COLON => [ #= : .. =# '…', '⁝', '⋮', '⋱', '⋰', '⋯'],
+    PREC_PLUS =>
+        [ #= + - ± ∓ ++ =#
+         '⊕', '⊖', '⊞', '⊟', '|', '∪', '∨',
+         '⊔', '±', '∓', '∔', '∸', '≏', '⊎', '⊻', '⊽', '⋎', '⋓', '⟇', '⧺',
+         '⧻', '⨈', '⨢', '⨣', '⨤', '⨥', '⨦', '⨧', '⨨', '⨩', '⨪', '⨫', '⨬', '⨭',
+         '⨮', '⨹', '⨺', '⩁', '⩂', '⩅', '⩊', '⩌', '⩏', '⩐', '⩒', '⩔', '⩖', '⩗',
+         '⩛', '⩝', '⩡', '⩢', '⩣', '¦'],
+    PREC_TIMES =>
+        [ #= * ⋆ & =#
+         '/', '÷', '%', '⋅', '·', '·', '∘', '×', '\\', '∩', '∧', '⊗',
+         '⊘', '⊙', '⊚', '⊛', '⊠', '⊡', '⊓', '∗', '∙', '∤', '⅋', '≀', '⊼', '⋄', '⋆',
+         '⋇', '⋉', '⋊', '⋋', '⋌', '⋏', '⋒', '⟑', '⦸', '⦼', '⦾', '⦿', '⧶', '⧷',
+         '⨇', '⨰', '⨱', '⨲', '⨳', '⨴', '⨵', '⨶', '⨷', '⨸', '⨻', '⨼', '⨽', '⩀',
+         '⩃', '⩄', '⩋', '⩍', '⩎', '⩑', '⩓', '⩕', '⩘', '⩚', '⩜', '⩞', '⩟', '⩠',
+         '⫛', '⊍', '▷', '⨝', '⟕', '⟖', '⟗', '⌿', '⨟',
+         '\u00b7', # '·' Middle Dot
+         '\u0387'  # '·' Greek Ano Teleia
+         ],
+    PREC_RATIONAL => Char[#= // =#],
+    PREC_BITSHIFT => Char[#= << >> >>> =#],
+    PREC_POWER    => ['^', '↑', '↓', '⇵', '⟰', '⟱', '⤈', '⤉', '⤊', '⤋', '⤒', '⤓', '⥉',
+                      '⥌', '⥍', '⥏', '⥑', '⥔', '⥕', '⥘', '⥙', '⥜', '⥝', '⥠', '⥡', '⥣', '⥥',
+                      '⥮', '⥯', '￪', '￬'],
+)
 
 #-------------------------------------------------------------------------------
 const _nonunique_kind_names = Set([
@@ -1157,7 +591,7 @@ is_keyword(k::Kind) = K"BEGIN_KEYWORDS" <= k <= K"END_KEYWORDS"
 is_block_continuation_keyword(k::Kind) = K"BEGIN_BLOCK_CONTINUATION_KEYWORDS" <= k <= K"END_BLOCK_CONTINUATION_KEYWORDS"
 is_literal(k::Kind) = K"BEGIN_LITERAL" <= k <= K"END_LITERAL"
 is_number(k::Kind)  = K"BEGIN_NUMBERS" <= k <= K"END_NUMBERS"
-is_operator(k::Kind) = K"BEGIN_OPS" <= k <= K"END_OPS"
+is_operator(k::Kind) = k == K"Operator" || K"BEGIN_OPS" <= k <= K"END_OPS"
 is_word_operator(k::Kind) = (k == K"in" || k == K"isa" || k == K"where")
 
 is_identifier(x) = is_identifier(kind(x))
@@ -1172,28 +606,30 @@ is_word_operator(x) = is_word_operator(kind(x))
 # Predicates for operator precedence
 # FIXME: Review how precedence depends on dottedness, eg
 # https://github.com/JuliaLang/julia/pull/36725
+
+
 is_prec_assignment(x)  = K"BEGIN_ASSIGNMENTS" <= kind(x) <= K"END_ASSIGNMENTS"
-is_prec_pair(x)        = K"BEGIN_PAIRARROW"   <= kind(x) <= K"END_PAIRARROW"
-is_prec_conditional(x) = K"BEGIN_CONDITIONAL" <= kind(x) <= K"END_CONDITIONAL"
-is_prec_arrow(x)       = K"BEGIN_ARROW"       <= kind(x) <= K"END_ARROW"
-is_prec_lazy_or(x)     = K"BEGIN_LAZYOR"      <= kind(x) <= K"END_LAZYOR"
-is_prec_lazy_and(x)    = K"BEGIN_LAZYAND"     <= kind(x) <= K"END_LAZYAND"
-is_prec_comparison(x)  = K"BEGIN_COMPARISON"  <= kind(x) <= K"END_COMPARISON"
-is_prec_pipe(x)        = K"BEGIN_PIPE"        <= kind(x) <= K"END_PIPE"
-is_prec_colon(x)       = K"BEGIN_COLON"       <= kind(x) <= K"END_COLON"
-is_prec_plus(x)        = K"BEGIN_PLUS"        <= kind(x) <= K"END_PLUS"
-is_prec_bitshift(x)    = K"BEGIN_BITSHIFTS"   <= kind(x) <= K"END_BITSHIFTS"
-is_prec_times(x)       = K"BEGIN_TIMES"       <= kind(x) <= K"END_TIMES"
-is_prec_rational(x)    = K"BEGIN_RATIONAL"    <= kind(x) <= K"END_RATIONAL"
-is_prec_power(x)       = K"BEGIN_POWER"       <= kind(x) <= K"END_POWER"
-is_prec_decl(x)        = K"BEGIN_DECL"        <= kind(x) <= K"END_DECL"
-is_prec_where(x)       = K"BEGIN_WHERE"       <= kind(x) <= K"END_WHERE"
-is_prec_dot(x)         = K"BEGIN_DOT"         <= kind(x) <= K"END_DOT"
-is_prec_unicode_ops(x) = K"BEGIN_UNICODE_OPS" <= kind(x) <= K"END_UNICODE_OPS"
-is_prec_pipe_lt(x)     = kind(x) == K"<|"
-is_prec_pipe_gt(x)     = kind(x) == K"|>"
+is_prec_pair(x)        = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_PAIRARROW))
+is_prec_conditional(x) = kind(x) == K"?"
+is_prec_arrow(x)       = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_ARROW)) || kind(x) == K"-->"
+is_prec_lazy_or(x)     = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_LAZYOR)) || kind(x) in KSet"||"
+is_prec_lazy_and(x)    = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_LAZYAND)) || kind(x) in KSet"&&"
+is_prec_comparison(x)  = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_COMPARISON)) || kind(x) in KSet"<: >: in isa < > ∈"
+is_prec_pipe_lt(x)     = kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_PIPE_LT)
+is_prec_pipe_gt(x)     = kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_PIPE_GT)
+is_prec_pipe(x)        = is_prec_pipe_lt(x) || is_prec_pipe_gt(x)
+is_prec_colon(x)       = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_COLON)) || kind(x) == K".."
+is_prec_plus(x)        = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_PLUS)) || kind(x) in KSet"+ - ± ∓"
+is_prec_bitshift(x)    = kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_BITSHIFT)
+is_prec_times(x)       = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_TIMES)) || kind(x) in KSet"* ⋆ &"
+is_prec_rational(x)    = kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_RATIONAL)
+is_prec_power(x)       = kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_POWER)
+is_prec_decl(x)        = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_DECL)) || kind(x) == K"::"
+is_prec_where(x)       = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_WHERE)) || kind(x) == K"where"
+is_prec_dot(x)         = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_DOT)) || kind(x) == K"."
+is_prec_quote(x)       = (kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_QUOTE)) || kind(x) == K"'"
 is_syntax_kind(x)      = K"BEGIN_SYNTAX_KINDS"<= kind(x) <= K"END_SYNTAX_KINDS"
-is_syntactic_assignment(x) = K"BEGIN_SYNTACTIC_ASSIGNMENTS" <= kind(x) <= K"END_SYNTACTIC_ASSIGNMENTS"
+is_prec_compound_assign(x) = kind(x) == K"Operator" && numeric_flags(head(x)) == Int(PREC_COMPOUND_ASSIGN)
 
 function is_string_delim(x)
     kind(x) in (K"\"", K"\"\"\"")
@@ -1217,5 +653,5 @@ function is_syntactic_operator(x)
     # in the parser? The lexer itself usually disallows such tokens, so it's
     # not clear whether we need to handle them. (Though note `.->` is a
     # token...)
-    return k in KSet"&& || . ... ->" || is_syntactic_assignment(k)
+    return k in KSet"&& || . ... -> = :="
 end

--- a/src/julia/kinds.jl
+++ b/src/julia/kinds.jl
@@ -278,8 +278,6 @@ register_kinds!(JuliaSyntax, 0, [
     "ErrorInvalidOperator"
     "Error**"
 
-    "..."
-
     # Level 1
     "BEGIN_ASSIGNMENTS"
         "BEGIN_SYNTACTIC_ASSIGNMENTS"
@@ -774,7 +772,6 @@ register_kinds!(JuliaSyntax, 0, [
     # Level 8
     "BEGIN_COLON"
         ":"
-        ".."
         "…"
         "⁝"
         "⋮"
@@ -1033,6 +1030,10 @@ register_kinds!(JuliaSyntax, 0, [
         "typed_ncat"
         "row"
         "nrow"
+        # splat/slurp
+        "..."
+        # ../... as a identifier
+        "dots"
         # Comprehensions
         "generator"
         "filter"

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -14,6 +14,8 @@
         @test parseatom(":(a)") == QuoteNode(:a)
         @test parseatom(":(:a)") == Expr(:quote, QuoteNode(:a))
         @test parseatom(":(1+2)") == Expr(:quote, Expr(:call, :+, 1, 2))
+        @test parseatom(":...") == QuoteNode(Symbol("..."))
+        @test parseatom(":(...)") == QuoteNode(Symbol("..."))
         # Compatibility hack for VERSION >= v"1.4"
         # https://github.com/JuliaLang/julia/pull/34077
         @test parseatom(":true") == Expr(:quote, true)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -141,14 +141,14 @@ tests = [
         "1:\n2"     => "(call-i 1 : (error))"
     ],
     JuliaSyntax.parse_range => [
-        "a..b"       => "(call-i a .. b)"
+        "a..b"       => "(call-i a (dots-2) b)"
         "a … b"      => "(call-i a … b)"
         "a .… b"     => "(dotcall-i a … b)"
         "[1 :a]"     => "(hcat 1 (quote-: a))"
         "[1 2:3 :a]" =>  "(hcat 1 (call-i 2 : 3) (quote-: a))"
         "x..."     => "(... x)"
         "x:y..."   => "(... (call-i x : y))"
-        "x..y..."  => "(... (call-i x .. y))"
+        "x..y..."  => "(... (call-i x (dots-2) y))"
     ],
     JuliaSyntax.parse_invalid_ops => [
         "a--b"  =>  "(call-i a (ErrorInvalidOperator) b)"
@@ -719,7 +719,7 @@ tests = [
         "import A.:(+)" =>  "(import (importpath A (quote-: (parens +))))"
         "import A.=="   =>  "(import (importpath A ==))"
         "import A.⋆.f"  =>  "(import (importpath A ⋆ f))"
-        "import A..."   =>  "(import (importpath A ..))"
+        "import A..."   =>  "(import (importpath A (dots-2)))"
         "import A; B"   =>  "(import (importpath A))"
         # Colons not allowed first in import paths
         # but are allowed in trailing components (#473)
@@ -816,7 +816,7 @@ tests = [
         "&&"  =>  "(error &&)"
         "||"  =>  "(error ||)"
         "."   =>  "(error .)"
-        "..." =>  "(error ...)"
+        "..." =>  "(error (dots-3))"
         "+="  =>  "(error +=)"
         "-="  =>  "(error -=)"
         "*="  =>  "(error *=)"
@@ -1143,7 +1143,7 @@ parsestmt_with_kind_tests = [
     "a →  b" => "(call-i a::Identifier →::Identifier b::Identifier)"
     "a < b < c" => "(comparison a::Identifier <::Identifier b::Identifier <::Identifier c::Identifier)"
     "a .<: b"=> "(dotcall-i a::Identifier <:::Identifier b::Identifier)"
-    "a .. b" => "(call-i a::Identifier ..::Identifier b::Identifier)"
+    "a .. b" => "(call-i a::Identifier (dots-2) b::Identifier)"
     "a : b"  => "(call-i a::Identifier :::Identifier b::Identifier)"
     "-2^x"   => "(call-pre -::Identifier (call-i 2::Integer ^::Identifier x::Identifier))"
     "-(2)"   => "(call-pre -::Identifier (parens 2::Integer))"

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -214,8 +214,10 @@ tokensplit(str; kws...) = [kind(tok) => untokenize(tok, str) for tok in tokenize
         K"Integer" => "1",
     ]
 
-    # A predicate based on flags()
-    @test JuliaSyntax.is_suffixed(tokenize("+₁")[1])
+    # +₁ is tokenized as a single identifier token (subscripts are valid in identifiers)
+    tokens = tokenize("+₁")
+    @test length(tokens) == 1  # Just the identifier, endmarker is not included in tokenize()
+    @test kind(tokens[1]) == K"Identifier"
 
     # Buffer interface
     @test tokenize(Vector{UInt8}("a + b")) == tokenize("a + b")

--- a/test/tokenize.jl
+++ b/test/tokenize.jl
@@ -155,7 +155,7 @@ end # testset
 end # testset
 
 @testset "issue 5, '..'" begin
-    @test kind.(collect(tokenize("1.23..3.21"))) == [K"Float",K"..",K"Float",K"EndMarker"]
+    @test kind.(collect(tokenize("1.23..3.21"))) == [K"Float",K".",K".",K"Float",K"EndMarker"]
 end
 
 @testset "issue 17, >>" begin
@@ -712,10 +712,10 @@ end
     @test toks("1.#") == ["1."=>K"Float", "#"=>K"Comment"]
 
     # ellipses
-    @test toks("1..")    == ["1"=>K"Integer",   ".."=>K".."]
-    @test toks("1...")   == ["1"=>K"Integer",  "..."=>K"..."]
-    @test toks(".1..")   == [".1"=>K"Float",    ".."=>K".."]
-    @test toks("0x01..") == ["0x01"=>K"HexInt", ".."=>K".."]
+    @test toks("1..")    == ["1"=>K"Integer",   "."=>K".", "."=>K"."]
+    @test toks("1...")   == ["1"=>K"Integer",  "."=>K".", "."=>K".", "."=>K"."]
+    @test toks(".1..")   == [".1"=>K"Float",    "."=>K".", "."=>K"."]
+    @test toks("0x01..") == ["0x01"=>K"HexInt", "."=>K".", "."=>K"."]
 
     # Dotted operators and other dotted suffixes
     @test toks("1234 .+1") == ["1234"=>K"Integer", " "=>K"Whitespace", "."=>K".", "+"=>K"+", "1"=>K"Integer"]
@@ -876,8 +876,9 @@ end
     @test toks("--")      == ["--"=>K"ErrorInvalidOperator"]
     @test toks("1**2") == ["1"=>K"Integer", "**"=>K"Error**", "2"=>K"Integer"]
     @test toks("a<---b") == ["a"=>K"Identifier", "<---"=>K"ErrorInvalidOperator", "b"=>K"Identifier"]
-    @test toks("a..+b") == ["a"=>K"Identifier", "..+"=>K"ErrorInvalidOperator", "b"=>K"Identifier"]
-    @test toks("a..−b") == ["a"=>K"Identifier", "..−"=>K"ErrorInvalidOperator", "b"=>K"Identifier"]
+    # These used to test for invalid operators ..+ and ..−, but now .. is tokenized as two dots
+    @test toks("a..+b") == ["a"=>K"Identifier", "."=>K".", "."=>K".", "+"=>K"+", "b"=>K"Identifier"]
+    @test toks("a..−b") == ["a"=>K"Identifier", "."=>K".", "."=>K".", "−"=>K"-", "b"=>K"Identifier"]
 end
 
 @testset "hat suffix" begin


### PR DESCRIPTION
This replaces all the specialized operator heads by a single K"Operator" head that encodes the precedence level in its flags (except for operators that are also used for non-operator purposes). The operators are already K"Identifier" in the final parse tree. There is very little reason to spend all of the extra effort separating them into separate heads only to undo this later. Moreover, I think it's actively misleading, because it makes people think that they can query things about an operator by looking at the head, which doesn't work for suffixed operators.

Additionally, this removes the `op=` token, replacing it by two tokens, one K"Operator" with a special precendence level and one `=`. This then removes the last use of `bump_split` (since this PR is on top of #573).

As a free bonus this prepares us for having compound assignment syntax for suffixed operators, which was infeasible in the flips parser. That syntax change is not part of this PR but would be trivial (this PR makes it an explicit error).

Fixes #334