### PR TITLE
refactor: redundant lex in `lex_less`

### DIFF
--- a/src/julia/tokenize.jl
+++ b/src/julia/tokenize.jl
@@ -832,14 +832,10 @@ function lex_less(l::Lexer)
         readchar(l); readchar(l)
         if accept(l, '-')
             return emit(l, K"ErrorInvalidOperator")
+        elseif accept(l, '>')
+            return emit(l, K"<-->")
         else
-            if accept(l, '>')
-                return emit(l, K"<-->")
-            elseif accept(l, '-')
-                return emit(l, K"ErrorInvalidOperator")
-            else
-                return emit(l, K"<--")
-            end
+            return emit(l, K"<--")
         end
     else
         return emit(l, K"<")


### PR DESCRIPTION
There's a redundant `accept` found in `lex_less` while lexing `<-->` or `<--` related operators.