### PR TITLE
`_register_kinds!`: prevent unintentional closure capture, boxing

### DIFF
--- a/src/julia/kinds.jl
+++ b/src/julia/kinds.jl
@@ -102,6 +102,10 @@ function _register_kinds!(kind_modules, int_to_kindstr, kind_str_to_int, mod, mo
             error("Kind module ID $module_id already claimed by module $m")
         end
     end
+    _register_kinds_names!(int_to_kindstr, kind_str_to_int, module_id, names)
+end
+
+function _register_kinds_names!(int_to_kindstr, kind_str_to_int, module_id, names)
     # Process names to conflate category BEGIN/END markers with the first/last
     # in the category.
     i = 0

--- a/src/julia/kinds.jl
+++ b/src/julia/kinds.jl
@@ -105,6 +105,8 @@ function _register_kinds!(kind_modules, int_to_kindstr, kind_str_to_int, mod, mo
     _register_kinds_names!(int_to_kindstr, kind_str_to_int, module_id, names)
 end
 
+# This function is separated from `_register_kinds!` to prevent sharing of the variable `i`
+# here and in the closure in `_register_kinds!`, which causes boxing and bad inference.
 function _register_kinds_names!(int_to_kindstr, kind_str_to_int, module_id, names)
     # Process names to conflate category BEGIN/END markers with the first/last
     # in the category.


### PR DESCRIPTION
The variable `i` was unintentionally shared between the generator closure in `_register_kinds!` and another part of the body of `_register_kinds!`. Thus `i` was boxed, causing trouble for inference.

Fix this by moving the part of `_register_kinds!` with `i` to a new function.

Fixing this should make the sysimage more resistant to invalidation, once the change propagates to Julia itself.