### PR TITLE
backport to v1: `_register_kinds!`: improve type stability when creating `Vector`

### DIFF
--- a/src/kinds.jl
+++ b/src/kinds.jl
@@ -88,7 +88,7 @@ function _register_kinds!(kind_modules, int_to_kindstr, kind_str_to_int, mod, mo
             # Ok: known kind module, but not loaded until now
             kind_modules[module_id] = mod
         elseif m == mod
-            existing_kinds = [(i = get(kind_str_to_int, n, nothing);
+            existing_kinds = Union{Nothing, Kind}[(i = get(kind_str_to_int, n, nothing);
                                isnothing(i) ? nothing : Kind(i)) for n in names]
             if any(isnothing, existing_kinds) ||
                     !issorted(existing_kinds) ||


### PR DESCRIPTION
Make the temporary `existing_kinds::Vector` infer concretely.

NB: a more thorough solution might do away with the construction of `existing_kinds` altogether, however this seems like an OK quick fix.

(cherry picked from commit 27741256a1488c5016a3255afa76af56548cbe5d)

xref:

* the PR being backported: #587

* backport release PR #577