### PR TITLE
`typeassert` `Expr` constructor return value

### DIFF
--- a/src/integration/expr.jl
+++ b/src/integration/expr.jl
@@ -668,4 +668,4 @@ function to_expr(node)
     return fixup_Expr_child(wrapper_head, node_to_expr(node, source, txtbuf, UInt32(txtbuf_offset)), false)
 end
 
-Base.Expr(node::SyntaxNode) = to_expr(node)
+Base.Expr(node::SyntaxNode) = to_expr(node)::Expr

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -838,6 +838,6 @@ end
 
 @testset "SyntaxNode->Expr conversion" begin
     src = repeat('a', 1000) * '\n' * "@hi"
-    @test Expr(parsestmt(SyntaxNode, SubString(src, 1001:lastindex(src)))) ==
+    @test (@inferred Expr(parsestmt(SyntaxNode, SubString(src, 1001:lastindex(src))))) ==
         Expr(:macrocall, Symbol("@hi"), LineNumberNode(2))
 end


### PR DESCRIPTION
Type stability fix: makes the return value of the `Expr` constructor method infer as `Expr`.

Not sure if this could be fixed at a deeper level of the call stack instead.

Works around issue JuliaLang/julia#42372 in the case of this method.