### PR TITLE
type stability fix for `sourcetext`

### DIFF
--- a/src/core/parse_stream.jl
+++ b/src/core/parse_stream.jl
@@ -917,7 +917,7 @@ function sourcetext(stream::ParseStream; steal_textbuf=false)
     # unstable. (Also codeunit(root) == UInt8 doesn't imply UTF-8 encoding?)
     # if root isa AbstractString && codeunit(root) == UInt8
     #     return root
-    str = if root isa String || root isa SubString
+    str = if root isa String || root isa SubString{String}
         root
     elseif steal_textbuf
         String(stream.textbuf)


### PR DESCRIPTION
Changing `SubString` to the concrete `SubString{String}` should make Julia's sysimage more resistant to invalidation, once this change propagates to Julia proper.