### PR TITLE
Type-assert `opts.delim_flags` to reduce invalidations

### DIFF
--- a/src/julia/parser.jl
+++ b/src/julia/parser.jl
@@ -3171,8 +3171,8 @@ end
 # (a,b=1; c,d=2; e,f=3)  ==>  (tuple-p a (= b 1) (parameters c (= d 2)) (parameters e (= f 3)))
 #
 # flisp: parts of parse-paren- and parse-arglist
-function parse_brackets(after_parse::Function,
-                        ps::ParseState, closing_kind, generator_is_last=true)
+function parse_brackets(after_parse::F,
+                        ps::ParseState, closing_kind, generator_is_last=true) where {F <: Function}
     ps = ParseState(ps, range_colon_enabled=true,
                     space_sensitive=false,
                     where_enabled=true,


### PR DESCRIPTION
In particular the last line of invalidations from PythonCall.jl (CC @cjdoris):
```julia
 inserting |(x::Number, y::PythonCall.Py) @ PythonCall.Core ~/git/PythonCall.jl/src/Core/Py.jl:432 invalidated:
   mt_backedges: 1: signature Tuple{typeof(|), Int64, Any} triggered MethodInstance for Base.JuliaSyntax._register_kinds!(::Dict{Int64, Union{Module, Symbol}}, ::Dict{UInt16, String}, ::Dict{String, UInt16}, ::Module, ::Int64, ::Vector{String}) (0 children)
                 2: signature Tuple{typeof(|), Int64, Any} triggered MethodInstance for Base.JuliaSyntax._register_kinds!(::Dict{Int64, Union{Module, Symbol}}, ::Dict{UInt16, String}, ::Dict{String, UInt16}, ::Module, ::Int64, ::Vector{String}) (0 children)
                 3: signature Tuple{typeof(|), Int64, Any} triggered MethodInstance for JuliaSyntax._register_kinds!(::Dict{Int64, Union{Module, Symbol}}, ::Dict{UInt16, String}, ::Dict{String, UInt16}, ::Module, ::Int64, ::Vector{String}) (0 children)
                 4: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for <=(::Any, ::Char) (0 children)
                 5: signature Tuple{typeof(|), Bool, Any} triggered MethodInstance for <=(::Char, ::Any) (9 children)
                 6: signature Tuple{typeof(|), UInt16, Any} triggered MethodInstance for Base.JuliaSyntax.parse_function_signature(::Base.JuliaSyntax.ParseState, ::Bool) (1155 children)
```

The issue is that `ops.delim_flags` was getting inferred to `Any`:
```julia
2220                 ambiguous_parens::Bool = opts::NamedTuple.maybe_grouping_parens::Any &&                                                                                                                                                   
2221                                    (peek_behind(ps::JuliaSyntax.ParseState)::@NamedTuple{kind::JuliaSyntax.Kind, flags::UInt16, orig_kind::JuliaSyntax.Kind, is_leaf::Bool}.kind::JuliaSyntax.Kind in KSet"macrocall $")::Bool            
2222                 emit(ps::JuliaSyntax.ParseState, mark::JuliaSyntax.ParseStreamPosition, K"tuple", (PARENS_FLAG::Core.Const(0x0100)|opts::NamedTuple.delim_flags::Any)::Any)                                                               
2223                 if ambiguous_parens::Bool                                                                                                                                                                                                 
```

But from reading `parse_brackets()` I think it's safe to restrict it to a `RawFlags`