### PR TITLE
Fix InexactError in peek_behind_pos when skipping nested trivia nodes

### DIFF
--- a/src/core/parse_stream.jl
+++ b/src/core/parse_stream.jl
@@ -635,8 +635,14 @@ function peek_behind_pos(stream::ParseStream; skip_trivia::Bool=true,
     while node_idx > 0
         node = stream.output[node_idx]
         if kind(node) == K"TOMBSTONE" || (skip_trivia && is_trivia(node))
-            node_idx -= 1
             byte_idx -= node.byte_span
+            # If this is a non-terminal node, skip its children without
+            # subtracting their byte_spans, as they're already included in the parent
+            if is_non_terminal(node)
+                node_idx -= (1 + node.node_span)
+            else
+                node_idx -= 1
+            end
         else
             break
         end

--- a/test/parse_stream.jl
+++ b/test/parse_stream.jl
@@ -156,3 +156,13 @@ end
     @test ParseStream(y) isa ParseStream
     @test parsestmt(Expr, y) == parsestmt(Expr, "1")
 end
+
+@testset "peek_behind_pos with negative byte index" begin
+    # Test that peek_behind_pos doesn't cause InexactError when byte_idx goes negative
+    # This can happen when parsing certain incomplete keywords like "do"
+    # where trivia skipping walks back past the beginning of the stream
+    @test_throws JuliaSyntax.ParseError parseall(GreenNode, "do")
+    @test_throws JuliaSyntax.ParseError parseall(GreenNode, "do ")
+    @test_throws JuliaSyntax.ParseError parseall(GreenNode, " do")
+    @test_throws JuliaSyntax.ParseError parseall(GreenNode, "do\n")
+end


### PR DESCRIPTION
Explanation of bug written below by Claude :robot. Fixes https://github.com/JuliaLang/julia/issues/60084

------------------

When parsing certain incomplete keywords like "do", the parser would crash
with `InexactError: trunc(UInt32, -1)` instead of returning a ParseError.

Root cause:
-----------
The peek_behind_pos function walks backwards through the flat output array,
subtracting byte_spans to calculate byte positions. However, when a non-terminal
trivia node contains child nodes, both the parent and children exist in the
output array with overlapping byte_spans. The old code would subtract the
byte_span of both the parent and its children, causing byte_idx to go negative.

Example with input "do":
------------------------
The parser creates this output structure:
  [1] TOMBSTONE (byte_span=0)
  [2] "do" token (byte_span=2, is_trivia=true, covers bytes 1-2)
  [3] error node (byte_span=2, is_trivia=true, node_span=1, covers bytes 1-2)
      └── contains node [2] as a child

When peek_behind_pos walks backwards from next_byte=3:
  Old behavior:
    - Start: byte_idx = 3, node_idx = 3
    - Skip error node [3]: byte_idx = 3 - 2 = 1, node_idx = 2
    - Skip "do" node [2]: byte_idx = 1 - 2 = -1 ❌ (tries to convert to UInt32)

  The problem: Both nodes cover the same bytes (1-2), so subtracting both
  spans double-counts the same 2 bytes.

Solution:
---------
When skipping a non-terminal node, also skip all its children without
subtracting their byte_spans, since the parent's byte_span already includes
them:

  if is_non_terminal(node)
      node_idx -= (1 + node.node_span)  # Skip the node + all its children
  else
      node_idx -= 1
  end

New behavior:
  - Start: byte_idx = 3, node_idx = 3
  - Skip error node [3]: byte_idx = 3 - 2 = 1, node_idx = 3 - (1 + 1) = 1
  - Stop at TOMBSTONE [1] (not trivia)
  - Return: byte_idx = 1, node_idx = 1 ✓

Why "do" was unique:
--------------------
The "do" keyword is the only Julia keyword that:
1. Gets marked as TRIVIA when appearing standalone (invalid syntax)
2. Has an error node emitted that wraps it (also marked as TRIVIA)
3. Continues parsing afterward, eventually calling peek_behind

Other incomplete keywords either parse successfully or fail earlier before
reaching the code path that calls peek_behind.
