### PR TITLE
Convert last_byte(stream) to Int in core_parser_hook

### DIFF
--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -168,7 +168,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
                 # If we're at the end of stream after skipping whitespace, just
                 # return `nothing` to indicate this rather than attempting to
                 # parse a statement or atom and failing.
-                return Core.svec(nothing, last_byte(stream))
+                return Core.svec(nothing, Int(last_byte(stream)))
             end
         end
         parse!(stream; rule=options)
@@ -239,7 +239,7 @@ function core_parser_hook(code, filename::String, lineno::Int, offset::Int, opti
         # Note the next byte in 1-based indexing is `last_byte(stream) + 1` but
         # the Core hook must return an offset (ie, it's 0-based) so the factors
         # of one cancel here.
-        last_offset = last_byte(stream)
+        last_offset = Int(last_byte(stream))
 
         if !isnothing(_debug_log[])
             println(_debug_log[], """


### PR DESCRIPTION
Julia's `jl_parse` will type check the second element of the SimpleVector returned from core_parser_hook against `Int`.  On newer JuliaSyntax, `last_byte(::ParseStream)` returns Int, but on 1.12, it returns UInt32 on 32 bit platforms, causing `jl_parse` to fail.  Fixes JuliaLang/julia#60417.