### PR TITLE
Specialize `parse_brackets()` on the input function (1.13 backport)

### DIFF
--- a/src/julia/parser.jl
+++ b/src/julia/parser.jl
@@ -3166,8 +3166,8 @@ end
 # (a,b=1; c,d=2; e,f=3)  ==>  (tuple-p a (= b 1) (parameters c (= d 2)) (parameters e (= f 3)))
 #
 # flisp: parts of parse-paren- and parse-arglist
-function parse_brackets(after_parse::Function,
-                        ps::ParseState, closing_kind, generator_is_last=true)
+function parse_brackets(after_parse::F,
+                        ps::ParseState, closing_kind, generator_is_last=true) where {F}
     ps = ParseState(ps, range_colon_enabled=true,
                     space_sensitive=false,
                     where_enabled=true,


### PR DESCRIPTION
CC @KristofferC.