### PR TITLE
[backports-release-1] labeled break/continue support

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2001,15 +2001,60 @@ function parse_resword(ps::ParseState)
             parse_eq(ps)
         end
         emit(ps, mark, K"return")
-    elseif word in KSet"break continue"
-        # break     ==>  (break)
-        # continue  ==>  (continue)
+    elseif word == K"continue"
+        # continue         ==>  (continue)
+        # continue _       ==>  (continue _)        [1.14+]
+        # continue label   ==>  (continue label)    [1.14+]
         bump(ps, TRIVIA_FLAG)
-        emit(ps, mark, word)
         k = peek(ps)
-        if !(k in KSet"NewlineWs ; ) : EndMarker" || (k == K"end" && !ps.end_symbol))
-            recover(is_closer_or_newline, ps, TRIVIA_FLAG,
-                    error="unexpected token after $(untokenize(word))")
+        if k in KSet"NewlineWs ; ) EndMarker" || (k == K"end" && !ps.end_symbol)
+            # continue with no arguments
+            emit(ps, mark, K"continue")
+        elseif ps.range_colon_enabled && k == K":"
+            # Ternary case: `cond ? continue : x`
+            emit(ps, mark, K"continue")
+        elseif k == K"Identifier" || is_contextual_keyword(k)
+            # continue label - plain identifier or contextual keyword as label
+            bump(ps)
+            emit(ps, mark, K"continue")
+            min_supported_version(v"1.14", ps, mark, "labeled `continue`")
+        else
+            # Error: unexpected token after continue
+            emit(ps, mark, K"continue")
+        end
+    elseif word == K"break"
+        # break            ==>  (break)
+        # break _          ==>  (break _)               [1.14+]
+        # break _ val      ==>  (break _ val)           [1.14+]
+        # break label      ==>  (break label)           [1.14+]
+        # break label val  ==>  (break label val)       [1.14+]
+        bump(ps, TRIVIA_FLAG)
+        function parse_break_value(ps, mark)
+            k2 = peek(ps)
+            if k2 in KSet"NewlineWs ; ) : EndMarker" || (k2 == K"end" && !ps.end_symbol)
+                # break label
+                emit(ps, mark, K"break")
+            else
+                # break label value
+                parse_eq(ps)
+                emit(ps, mark, K"break")
+            end
+            min_supported_version(v"1.14", ps, mark, "labeled `break`")
+        end
+        k = peek(ps)
+        if k in KSet"NewlineWs ; ) EndMarker" || (k == K"end" && !ps.end_symbol)
+            # break with no arguments
+            emit(ps, mark, K"break")
+        elseif ps.range_colon_enabled && k == K":"
+            # Ternary case: `cond ? break : x`
+            emit(ps, mark, K"break")
+        elseif k == K"Identifier" || is_contextual_keyword(k)
+            # break label [value] - plain identifier or contextual keyword as label
+            bump(ps)
+            parse_break_value(ps, mark)
+        else
+            # Error: unexpected token after break
+            emit(ps, mark, K"break")
         end
     elseif word in KSet"module baremodule"
         # module A end  ==> (module A (block))

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -534,6 +534,13 @@ tests = [
         # break/continue
         "break"    => "(break)"
         "continue" => "(continue)"
+        # break/continue with labels (plain identifiers only, requires 1.14+)
+        ((v=v"1.14",), "break _")  => "(break _)"
+        ((v=v"1.14",), "break _ x") => "(break _ x)"
+        ((v=v"1.14",), "break label") => "(break label)"
+        ((v=v"1.14",), "break label x") => "(break label x)"
+        ((v=v"1.14",), "continue _") => "(continue _)"
+        ((v=v"1.14",), "continue label") => "(continue label)"
         # module/baremodule
         "module A end"      =>  "(module A (block))"
         "baremodule A end"  =>  "(module-bare A (block))"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -64,9 +64,28 @@ function remove_macro_linenums!(ex)
     return ex
 end
 
-function remove_all_linenums!(ex)
+function remove_module_versions!(ex)
+    # In v1.14+, JuliaSyntax adds a version as the first argument to module expressions.
+    # Remove it for comparison with flisp output.
+    if Meta.isexpr(ex, :module) && length(ex.args) >= 1 && ex.args[1] isa VersionNumber
+        deleteat!(ex.args, 1)
+    end
+    if ex isa Expr
+        for arg in ex.args
+            remove_module_versions!(arg)
+        end
+    end
+    return ex
+end
+
+function remove_all_linenums_and_modvers!(ex)
     JuliaSyntax.remove_linenums!(ex)
     remove_macro_linenums!(ex)
+    remove_module_versions!(ex)
+end
+
+function remove_all_linenums!(ex)
+    remove_all_linenums_and_modvers!(ex)
 end
 
 function kw_to_eq(ex)
@@ -96,7 +115,7 @@ function triple_string_roughly_equal(fl_str, str)
 end
 
 function exprs_equal_no_linenum(fl_ex, ex)
-    remove_all_linenums!(deepcopy(ex)) == remove_all_linenums!(deepcopy(fl_ex))
+    remove_all_linenums_and_modvers!(deepcopy(ex)) == remove_all_linenums_and_modvers!(deepcopy(fl_ex))
 end
 
 function is_eventually_call(ex)
@@ -131,7 +150,7 @@ function exprs_roughly_equal(fl_ex, ex)
     args = ex.head in (:block, :quote, :toplevel) ?
            filter(x->!(x isa LineNumberNode), ex.args) :
            ex.args
-    if (fl_ex.head == :block && ex.head == :tuple && 
+    if (fl_ex.head == :block && ex.head == :tuple &&
         length(fl_args) == 2 && length(args) == 2 &&
         Meta.isexpr(args[1], :parameters, 1) &&
         exprs_roughly_equal(fl_args[2], args[1].args[1]) &&
@@ -171,6 +190,10 @@ function exprs_roughly_equal(fl_ex, ex)
         # The flisp parser adds an extra block around `w` in the following case
         # f(::g(z) = w) = 1
         fl_args[2] = fl_args[2].args[2]
+    elseif h == :module && length(args) == length(fl_args) + 1 && args[1] isa VersionNumber
+        # In v1.14+, JuliaSyntax adds a version as the first argument to module expressions.
+        # Skip the version when comparing.
+        args = args[2:end]
     end
     if length(fl_args) != length(args)
         return false
@@ -209,7 +232,7 @@ function parsers_agree_on_file(text, filename; exprs_equal=exprs_equal_no_linenu
         return true
     end
     try
-        stream = ParseStream(text)
+        stream = ParseStream(text; version=v"1.14")
         parse!(stream)
         ex = build_tree(Expr, stream, filename=filename)
         return !JuliaSyntax.any_error(stream) && exprs_equal(fl_ex, ex)


### PR DESCRIPTION
Backports JuliaLang/julia#60481 (commit 8dab3f0623) to support parsing Julia 1.14+ source code.