### PR TITLE
readme: Update julia backport branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 > Starting with version 2.0, active development has moved to [`JuliaSyntax/` in the `JuliaLang/julia` repository](https://github.com/JuliaLang/julia/tree/master/JuliaSyntax) (for Julia 1.14+).
 > 
 > New issues and PRs should not be created here, except for backports to Julia version ≤ 1.13 or JuliaSyntax ≤ 1.0:
-> - Julia 1.13: [backports-julialang-1.13](https://github.com/JuliaLang/JuliaSyntax.jl/tree/backports-julialang-1.13)
-> - Julia 1.12: [backports-julialang-1.12](https://github.com/JuliaLang/JuliaSyntax.jl/tree/backports-julialang-1.12)
+> - Julia 1.13: [release-1.13](https://github.com/JuliaLang/JuliaSyntax.jl/tree/release-1.13)
+> - Julia 1.12: [release-1.12](https://github.com/JuliaLang/JuliaSyntax.jl/tree/release-1.12)
 > - JuliaSyntax 1.0 (as a package): [backports-release-1](https://github.com/JuliaLang/JuliaSyntax.jl/tree/backports-release-1)
 
 # JuliaSyntax


### PR DESCRIPTION
@KristofferC changed 1.13 to use `release-1.13` for consistency with other stdlibs.  1.12 still uses `backports-julialang-1.12`, but that can be switched over next time we bump the JuliaSyntax version.