### PR TITLE
Only emit ternary `:`-spacing diagnostics when a `:` is present

### DIFF
--- a/src/julia/parser.jl
+++ b/src/julia/parser.jl
@@ -686,19 +686,20 @@ function parse_cond(ps::ParseState)
     end
     parse_eq_star(ParseState(ps, range_colon_enabled=false))
     t = peek_token(ps)
-    if !preceding_whitespace(t)
+    had_colon = kind(t) == K":"
+    if had_colon && !preceding_whitespace(t)
         # a ? b: c  ==>  (? a b (error-t) c)
         bump_invisible(ps, K"error", TRIVIA_FLAG,
                        error="space required before `:` in `?` expression")
     end
-    if kind(t) == K":"
+    if had_colon
         bump(ps, TRIVIA_FLAG)
     else
         # a ? b c  ==>  (? a b (error-t) c)
         bump_invisible(ps, K"error", TRIVIA_FLAG, error="`:` expected in `?` expression")
     end
     t = peek_token(ps; skip_newlines = true)
-    if !preceding_whitespace(t)
+    if had_colon && !preceding_whitespace(t)
         # a ? b :c  ==>  (? a b (error-t) c)
         bump_invisible(ps, K"error", TRIVIA_FLAG,
                        error="space required after `:` in `?` expression")

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -92,6 +92,7 @@ tests = [
         "a ? b: c"    => "(? a b (error-t) c)"
         "a ? b :c"    => "(? a b (error-t) c)"
         "a ? b c"     => "(? a b (error-t) c)"
+        "a ? b)"      => "(? a b (error-t) (error))"
         "A[x ? y : end]" => "(ref A (? x y end))"
     ],
     JuliaSyntax.parse_arrow => [


### PR DESCRIPTION
`parse_cond` emits "space required before `:` in `?` expression" and
"space required after `:` in `?` expression" unconditionally, but those
checks assume a `:` is actually present. When the `:` is missing, parsing a
ternary like `a ? b)` already reports the correct "`:` expected in `?`
expression", yet the two spacing diagnostics still fire — so the user is told
to add whitespace around a `:` that does not exist (#429).

This gates both spacing diagnostics on the `:` token being present, via a
`had_colon` flag computed once. The "`:` expected" path and the surrounding
recovery are unchanged; cases that do contain a `:` (`a ? b: c`,
`a ? b :c`, `a ? b:c`) still report the spacing errors as before.

Adds a `parse_cond` test for the no-`:` case: `a ? b)` parses to
`(? a b (error-t) (error))` — a single `(error-t)` for the missing `:`,
with no spurious spacing-error node.

Fixes #429

Disclosure: this pull request was written with the assistance of generative AI; all claims were verified against source, and human-reviewed.
