### PR TITLE
Backport-0.4: Consistent attachment of syntax trivia to top level statements (#495)

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -453,6 +453,7 @@ function parse_toplevel(ps::ParseState)
             bump_trivia(ps)
             break
         else
+            bump_trivia(ps)
             parse_stmts(ps)
         end
     end

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -68,6 +68,21 @@
                           :body,
                      ),
                 )
+
+            @test parseall("a\n\nx") ==
+                Expr(:toplevel,
+                    LineNumberNode(1),
+                    :a,
+                    LineNumberNode(3),
+                    :x
+                )
+            @test parseall("a\n\nx;y") ==
+                Expr(:toplevel,
+                    LineNumberNode(1),
+                    :a,
+                    LineNumberNode(3),
+                    Expr(:toplevel, :x, :y)
+                )
         end
 
         @testset "Function definition lines" begin


### PR DESCRIPTION
backport #495 to release-0.4 to fix https://github.com/JuliaLang/julia/issues/57645